### PR TITLE
Refactor: Categoria ya no depende de código de base de datos ni de la API REST

### DIFF
--- a/src/main/java/co/edu/unicauca/deporteParaTodos/aplicacion/puertos/puertosEntrada/ICategoriaCursoServicio.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/aplicacion/puertos/puertosEntrada/ICategoriaCursoServicio.java
@@ -2,7 +2,7 @@ package co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada;
 
 import java.util.List;
 
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.CategoriaDto;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Categoria;
 
 public interface ICategoriaCursoServicio {
 
@@ -10,35 +10,35 @@ public interface ICategoriaCursoServicio {
      * retorna las categorias disponibles en el sistema, aquellas marcadas como eliminadas no seran retornadas
      * @return lista de categorias
      */
-    public List<CategoriaDto> recuperarCategoriasCurso();
+    public List<Categoria> recuperarCategoriasCurso();
 
     /**
      * Insertar una categoria en el sistema
      * @param categoria categoria a insertar
      * @return categoria insertada
      */
-    public CategoriaDto insertarCategoria(CategoriaDto categoria);
+    public Categoria insertarCategoria(Categoria categoria);
 
     /**
      * Recupera una categoria a partir de su identificador
      * @param tituloCategoria identificador
      * @return categoria recuperada
      */
-    public CategoriaDto obtenerCategoriaCursoPorId(String tituloCategoria);
+    public Categoria obtenerCategoriaCursoPorId(String tituloCategoria);
 
     /**
-     * actualiza la infomracion de la categoria y retorna sus datos actualizados
+     * actualiza la informacion de la categoria y retorna sus datos actualizados
      * @param titulo
      * @param datosCategoria
      * @return
      */
-    public CategoriaDto actualizarCategoria(String titulo, CategoriaDto datosCategoria);
+    public Categoria actualizarCategoria(String titulo, Categoria datosCategoria);
 
     /**
      * elimina o marca como eliminada una categoria, dependiendo de sus dependencias asociadas
      * @param tituloCategoria identificador de la categoria
      * @return categoria eliminada o marcada
      */
-    public CategoriaDto eliminarCategoria(String tituloCategoria);
+    public Categoria eliminarCategoria(String tituloCategoria);
 
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/modelo/Categoria.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/modelo/Categoria.java
@@ -2,8 +2,6 @@ package co.edu.unicauca.deporteParaTodos.dominio.modelo;
 
 import java.util.List;
 
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.CategoriaDto;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.CategoriaCursoEntidad;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,28 +25,4 @@ public class Categoria {
 
     private int eliminado;
 
-    static public Categoria fabricarDeEntidad(CategoriaCursoEntidad entidad){
-        try{
-            Categoria fabricado = new Categoria();
-            fabricado.setTitulo(entidad.getTitulo());
-            fabricado.setDescripcion(entidad.getDescripcion());
-            fabricado.setImagen(entidad.getCat_imagen());
-            fabricado.setEliminado(entidad.getEliminado());
-            return fabricado;
-        }catch(Exception e){
-            return null;
-        }
-    }
-
-    static public Categoria fabricarDeDto(CategoriaDto dto){
-        try{
-            Categoria fabricado = new Categoria();
-            fabricado.setTitulo(dto.getTitulo());
-            fabricado.setDescripcion(dto.getDescripcion());
-            fabricado.setImagen(dto.getImagenId());
-            return fabricado;
-        }catch(Exception e){
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/CategoriaCursoServicio.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/CategoriaCursoServicio.java
@@ -1,6 +1,5 @@
 package co.edu.unicauca.deporteParaTodos.dominio.servicios;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,10 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.ICategoriaCursoServicio;
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosSalida.ICategoriaCursoGateway;
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Categoria;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.CategoriaDto;
-import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.ErrorInternoException;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.InsercionFallidaExepcion;
-import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoConvertibleException;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoExisteExcepcion;
 
 @Service
@@ -24,81 +20,38 @@ public class CategoriaCursoServicio implements ICategoriaCursoServicio {
 
     @Transactional(readOnly = true)
     @Override
-    public List<CategoriaDto> recuperarCategoriasCurso() {
-        //no es necesario generar excepcion cuando la lista esta vacia
-        List<Categoria> categorias = categoriaCursoGateway.obtenerCategorias();
-        List<CategoriaDto> listaDtos = new ArrayList<>();
-        //Transformacion de datos
-        categorias.forEach(modelo ->{
-            CategoriaDto dto = CategoriaDto.fabricarDeModelo(modelo);
-            listaDtos.add(dto);
-        });
-        return listaDtos;
+    public List<Categoria> recuperarCategoriasCurso() {
+        return categoriaCursoGateway.obtenerCategorias();
     }
 
     @Transactional
     @Override
-    public CategoriaDto insertarCategoria(CategoriaDto dto) {
-        //transformacion de datos
-        Categoria modelo = Categoria.fabricarDeDto(dto);
-        if(modelo==null){
-            throw new NoConvertibleException();
-        }
-        //uso del gate
+    public Categoria insertarCategoria(Categoria modelo) {
         Categoria retorno = categoriaCursoGateway.registrarCategoria(modelo);
-        if(retorno==null){
+        if (retorno == null) {
             throw new InsercionFallidaExepcion("ha fallado el proceso");
         }
-        //transformacion de datos
-        CategoriaDto respuesta = CategoriaDto.fabricarDeModelo(retorno);
-        //retorno
-        return respuesta;
+        return retorno;
     }
 
     @Transactional(readOnly = true)
     @Override
-    public CategoriaDto obtenerCategoriaCursoPorId(String tituloCategoria) {
-        
-        Categoria op = categoriaCursoGateway.obtenerCategoria(tituloCategoria);
-
-        CategoriaDto respuesta = CategoriaDto.fabricarDeModelo(op);
-
-        if(respuesta==null){
-            throw new ErrorInternoException();
-        }
-        return respuesta;
+    public Categoria obtenerCategoriaCursoPorId(String tituloCategoria) {
+        return categoriaCursoGateway.obtenerCategoria(tituloCategoria);
     }
 
     @Transactional
     @Override
-    public CategoriaDto actualizarCategoria(String titulo, CategoriaDto datosCategoria) {
+    public Categoria actualizarCategoria(String titulo, Categoria datosCategoria) {
         if (!categoriaCursoGateway.existeCategoria(titulo)) {
             throw new NoExisteExcepcion("No se encuentra el registro de la categoria ");
         }
-
-        Categoria categoriaModelo = Categoria.fabricarDeDto(datosCategoria);
-
-        if(categoriaModelo == null){
-            throw new ErrorInternoException();
-        }
-
-        Categoria regitro = categoriaCursoGateway.actualizarCategoria(titulo, categoriaModelo);
-        CategoriaDto catRetorno = CategoriaDto.fabricarDeModelo(regitro);
-        
-        return catRetorno;
+        return categoriaCursoGateway.actualizarCategoria(titulo, datosCategoria);
     }
 
     @Transactional
     @Override
-    public CategoriaDto eliminarCategoria(String tituloCategoria) {
-        Categoria categoria = categoriaCursoGateway.eliminarCategoria(tituloCategoria);
-        if(categoria==null){
-            throw new ErrorInternoException();
-        }
-        CategoriaDto respuesta = CategoriaDto.fabricarDeModelo(categoria);
-        return respuesta;
+    public Categoria eliminarCategoria(String tituloCategoria) {
+        return categoriaCursoGateway.eliminarCategoria(tituloCategoria);
     }
-
-    
-
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/DTOs/CategoriaDto.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/DTOs/CategoriaDto.java
@@ -1,7 +1,6 @@
 package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs;
 
 
-import co.edu.unicauca.deporteParaTodos.dominio.modelo.Categoria;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -24,15 +23,4 @@ public class CategoriaDto {
     @NotNull(message = "{categoria.imagenid.null}")
     private Integer imagenId;
 
-    public static CategoriaDto fabricarDeModelo(Categoria modelo){
-        try{
-            CategoriaDto dto = new CategoriaDto();
-            dto.setTitulo(modelo.getTitulo());
-            dto.setDescripcion(modelo.getDescripcion());
-            dto.setImagenId(modelo.getImagen());
-            return dto;
-        }catch(Exception e){
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/CategoriaRest.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/CategoriaRest.java
@@ -1,6 +1,7 @@
 package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.api;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,8 +16,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.ICategoriaCursoServicio;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Categoria;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.CategoriaDto;
 import co.edu.unicauca.deporteParaTodos.infraestructura.logs.PeticionLogger;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.CategoriaMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -38,19 +41,20 @@ public class CategoriaRest {
 
     @Autowired
     private ICategoriaCursoServicio servicioCategoria;
-    
+
     @Operation(summary = "Obtener todas las categorias disponibles en el sistema")
     @ApiResponses(value ={
         @ApiResponse(responseCode = "200", description = "listado de categorias"),
     })
     @GetMapping("/categorias2")
-    public ResponseEntity<List<CategoriaDto>> obtenerCategoriasExistentes(){        
+    public ResponseEntity<List<CategoriaDto>> obtenerCategoriasExistentes(){
         PeticionLogger.log(LOGGER, "GET", "/api/v2/categorias2", "sin datos");
-        List<CategoriaDto> listaDtos = servicioCategoria.recuperarCategoriasCurso();
+        List<CategoriaDto> listaDtos = servicioCategoria.recuperarCategoriasCurso()
+            .stream().map(CategoriaMapper::toDto).collect(Collectors.toList());
         return new ResponseEntity<>(listaDtos, HttpStatus.OK);
     }
 
-    @Operation(summary = "Obtener categoria por titulo, independientemente si eesta marcada como eliminada")
+    @Operation(summary = "Obtener categoria por titulo, independientemente si esta marcada como eliminada")
     @ApiResponses(value ={
         @ApiResponse(responseCode = "200", description = "Elemento encontrado"),
         @ApiResponse(responseCode = "404", description = "Elemento no encontrado")
@@ -61,10 +65,10 @@ public class CategoriaRest {
             @RequestParam String titulo
         ) {
         PeticionLogger.log(LOGGER, "GET", "/api/v2/categoria", "titulo=" + titulo);
-        CategoriaDto dto = servicioCategoria.obtenerCategoriaCursoPorId(titulo);
-        return new ResponseEntity<>(dto,HttpStatus.OK);
+        Categoria categoria = servicioCategoria.obtenerCategoriaCursoPorId(titulo);
+        return new ResponseEntity<>(CategoriaMapper.toDto(categoria), HttpStatus.OK);
     }
-    
+
 
     @Operation(summary = "Inserta una categoria en el sistema, el id de la imagen debe corresponder a uno ya existente en el sistema")
     @ApiResponses(value ={
@@ -73,10 +77,10 @@ public class CategoriaRest {
     @PostMapping("/categoria")
     public ResponseEntity<CategoriaDto> postCategoria(@RequestBody @Valid CategoriaDto dto) {
         PeticionLogger.log(LOGGER, "POST", "/api/v2/categoria", dto);
-        CategoriaDto respuesta = servicioCategoria.insertarCategoria(dto);
-        return new ResponseEntity<>(respuesta, HttpStatus.CREATED);
+        Categoria guardado = servicioCategoria.insertarCategoria(CategoriaMapper.fromDto(dto));
+        return new ResponseEntity<>(CategoriaMapper.toDto(guardado), HttpStatus.CREATED);
     }
-    
+
     @Operation(summary = "Actualiza una categoria en el sistema, el id de la imagen debe corresponder a uno ya existente en el sistema")
     @ApiResponses(value ={
         @ApiResponse(responseCode = "200", description = "Operacion exitosa"),
@@ -84,8 +88,8 @@ public class CategoriaRest {
     @PutMapping("/categoria")
     public ResponseEntity<CategoriaDto> putCategoria(@RequestParam @NotBlank String titulo, @RequestBody @Valid CategoriaDto dto) {
         PeticionLogger.log(LOGGER, "PUT", "/api/v2/categoria", "titulo=" + titulo + ", body=" + dto);
-        CategoriaDto respuesta = servicioCategoria.actualizarCategoria(titulo, dto);
-        return new ResponseEntity<>(respuesta, HttpStatus.OK);
+        Categoria actualizado = servicioCategoria.actualizarCategoria(titulo, CategoriaMapper.fromDto(dto));
+        return new ResponseEntity<>(CategoriaMapper.toDto(actualizado), HttpStatus.OK);
     }
 
     /***
@@ -97,7 +101,7 @@ public class CategoriaRest {
     @DeleteMapping("/categoria")
     public ResponseEntity<CategoriaDto> deleteCategoria(@RequestParam @NotBlank String titulo){
         PeticionLogger.log(LOGGER, "DELETE", "/api/v2/categoria", "titulo=" + titulo);
-        CategoriaDto categoria = servicioCategoria.eliminarCategoria(titulo);
-        return new ResponseEntity<>(categoria, HttpStatus.OK);
+        Categoria categoria = servicioCategoria.eliminarCategoria(titulo);
+        return new ResponseEntity<>(CategoriaMapper.toDto(categoria), HttpStatus.OK);
     }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/entidades/CategoriaCursoEntidad.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/entidades/CategoriaCursoEntidad.java
@@ -19,8 +19,6 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 
-import co.edu.unicauca.deporteParaTodos.dominio.modelo.Categoria;
-
 @Setter
 @Getter
 @AllArgsConstructor
@@ -42,16 +40,4 @@ public class CategoriaCursoEntidad {
     @Column(name = "meta_eliminado")
     private int eliminado;
 
-    public static CategoriaCursoEntidad fabricarDeModelo(Categoria modelo, int eliminado){
-        try{
-            CategoriaCursoEntidad entidad = new CategoriaCursoEntidad();
-            entidad.setTitulo(modelo.getTitulo());
-            entidad.setDescripcion(modelo.getDescripcion());
-            entidad.setCat_imagen(modelo.getImagen());
-            entidad.setEliminado(eliminado);
-            return entidad;
-        }catch(Exception e){
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/CategoriaGateway.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/CategoriaGateway.java
@@ -10,6 +10,7 @@ import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresS
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.DependenciaFallida;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoConvertibleException;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoExisteExcepcion;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.CategoriaMapper;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.YaExisteElementoExcepcion;
 import java.util.List;
 import java.util.Optional;
@@ -35,7 +36,7 @@ public class CategoriaGateway implements ICategoriaCursoGateway {
         List<CategoriaCursoEntidad> listaEntidades = repoCategoria.findByEliminado(0);
         List<Categoria> listaCategorias = new ArrayList<>();
         listaEntidades.forEach(entidad ->{
-            Categoria categoria = Categoria.fabricarDeEntidad(entidad);
+            Categoria categoria = CategoriaMapper.toDominio(entidad);
             if(categoria!=null){
                 listaCategorias.add(categoria);
             }
@@ -48,7 +49,7 @@ public class CategoriaGateway implements ICategoriaCursoGateway {
         CategoriaCursoEntidad entidadRecuperada = repoCategoria.findById(nombreCategoria).orElseThrow(
             () -> new NoExisteExcepcion()
         );
-        return Categoria.fabricarDeEntidad(entidadRecuperada);
+        return CategoriaMapper.toDominio(entidadRecuperada);
     }
 
     @Override
@@ -64,7 +65,7 @@ public class CategoriaGateway implements ICategoriaCursoGateway {
         }
 
         //conversion de datos
-        CategoriaCursoEntidad entidadInsertar = CategoriaCursoEntidad.fabricarDeModelo(datosCategoria, 0);
+        CategoriaCursoEntidad entidadInsertar = CategoriaMapper.toEntidad(datosCategoria);
         if(entidadInsertar == null){
             throw new NoConvertibleException();
         }
@@ -73,7 +74,7 @@ public class CategoriaGateway implements ICategoriaCursoGateway {
         CategoriaCursoEntidad entidadInsertada = repoCategoria.save(entidadInsertar);
 
         //conversion
-        Categoria categoriacreada = Categoria.fabricarDeEntidad(entidadInsertada);
+        Categoria categoriacreada = CategoriaMapper.toDominio(entidadInsertada);
 
         return categoriacreada;
     }
@@ -95,7 +96,7 @@ public class CategoriaGateway implements ICategoriaCursoGateway {
         entidadCategoriaExistente.setCat_imagen(prmcategoria.getImagen());
         //actualizo
         CategoriaCursoEntidad entidadActualizada = repoCategoria.save(entidadCategoriaExistente);
-        return Categoria.fabricarDeEntidad(entidadActualizada);
+        return CategoriaMapper.toDominio(entidadActualizada);
     }
 
     @Override
@@ -112,7 +113,7 @@ public class CategoriaGateway implements ICategoriaCursoGateway {
 
         repoCategoria.marcarComoEliminado(nombreCategoria);
         entidad.setEliminado(1);
-        return Categoria.fabricarDeEntidad(entidad);
+        return CategoriaMapper.toDominio(entidad);
     }
 
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/CategoriaMapper.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/CategoriaMapper.java
@@ -1,0 +1,59 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.mappers;
+
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Categoria;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.CategoriaDto;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.CategoriaCursoEntidad;
+import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoProcesableEntidadException;
+
+public class CategoriaMapper {
+
+    public static Categoria toDominio(CategoriaCursoEntidad entidad) {
+        try {
+            Categoria fabricado = new Categoria();
+            fabricado.setTitulo(entidad.getTitulo());
+            fabricado.setDescripcion(entidad.getDescripcion());
+            fabricado.setImagen(entidad.getCat_imagen());
+            fabricado.setEliminado(entidad.getEliminado());
+            return fabricado;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static CategoriaCursoEntidad toEntidad(Categoria categoria) {
+        try {
+            CategoriaCursoEntidad entidad = new CategoriaCursoEntidad();
+            entidad.setTitulo(categoria.getTitulo());
+            entidad.setDescripcion(categoria.getDescripcion());
+            entidad.setCat_imagen(categoria.getImagen());
+            entidad.setEliminado(categoria.getEliminado());
+            return entidad;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static CategoriaDto toDto(Categoria categoria) {
+        try {
+            CategoriaDto dto = new CategoriaDto();
+            dto.setTitulo(categoria.getTitulo());
+            dto.setDescripcion(categoria.getDescripcion());
+            dto.setImagenId(categoria.getImagen());
+            return dto;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static Categoria fromDto(CategoriaDto dto) {
+        try {
+            Categoria fabricado = new Categoria();
+            fabricado.setTitulo(dto.getTitulo());
+            fabricado.setDescripcion(dto.getDescripcion());
+            fabricado.setImagen(dto.getImagenId());
+            return fabricado;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir CategoriaDto a dominio: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/CategoriaCursoServicioTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/CategoriaCursoServicioTest.java
@@ -2,10 +2,7 @@ package co.edu.unicauca.deporteParaTodos.dominio.servicios;
 
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosSalida.ICategoriaCursoGateway;
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Categoria;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.CategoriaDto;
-import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.ErrorInternoException;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.InsercionFallidaExepcion;
-import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoConvertibleException;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoExisteExcepcion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,23 +36,15 @@ class CategoriaCursoServicioTest {
         return c;
     }
 
-    private CategoriaDto categoriaDto() {
-        CategoriaDto dto = new CategoriaDto();
-        dto.setTitulo(TITULO);
-        dto.setDescripcion("Deportes acuaticos");
-        dto.setImagenId(1);
-        return dto;
-    }
-
     // ──────────────────────────────────────────────────────────────────────────
     // recuperarCategoriasCurso
     // ──────────────────────────────────────────────────────────────────────────
 
     @Test
-    void recuperarCategoriasCurso_listaNoVacia_retornaDtosMapeados() {
+    void recuperarCategoriasCurso_listaNoVacia_retornaCategorias() {
         when(categoriaCursoGateway.obtenerCategorias()).thenReturn(List.of(categoriaModelo()));
 
-        List<CategoriaDto> resultado = categoriaCursoServicio.recuperarCategoriasCurso();
+        List<Categoria> resultado = categoriaCursoServicio.recuperarCategoriasCurso();
 
         assertEquals(1, resultado.size());
         assertEquals(TITULO, resultado.get(0).getTitulo());
@@ -65,11 +54,10 @@ class CategoriaCursoServicioTest {
     @Test
     void recuperarCategoriasCurso_listaVacia_retornaListaVaciaSinExcepcion() {
         // DISEÑO INTENCIONAL (C): el servicio documenta explicitamente que no es necesario
-        // lanzar excepcion cuando la lista esta vacia. Diferente a obtenerAlumnos,
-        // obtenerInstructores, etc., que si lanzan ListadoVacioExcepcion.
+        // lanzar excepcion cuando la lista esta vacia.
         when(categoriaCursoGateway.obtenerCategorias()).thenReturn(List.of());
 
-        List<CategoriaDto> resultado = categoriaCursoServicio.recuperarCategoriasCurso();
+        List<Categoria> resultado = categoriaCursoServicio.recuperarCategoriasCurso();
 
         assertNotNull(resultado);
         assertTrue(resultado.isEmpty(),
@@ -81,10 +69,10 @@ class CategoriaCursoServicioTest {
     // ──────────────────────────────────────────────────────────────────────────
 
     @Test
-    void insertarCategoria_exitosa_retornaDtoMapeado() {
+    void insertarCategoria_exitosa_retornaCategoria() {
         when(categoriaCursoGateway.registrarCategoria(any(Categoria.class))).thenReturn(categoriaModelo());
 
-        CategoriaDto resultado = categoriaCursoServicio.insertarCategoria(categoriaDto());
+        Categoria resultado = categoriaCursoServicio.insertarCategoria(categoriaModelo());
 
         assertNotNull(resultado);
         assertEquals(TITULO, resultado.getTitulo());
@@ -92,21 +80,11 @@ class CategoriaCursoServicioTest {
     }
 
     @Test
-    void insertarCategoria_dtoNulo_lanzaNoConvertibleException() {
-        // Categoria.fabricarDeDto(null) lanza NPE internamente, la captura y retorna null.
-        // El servicio detecta el null y lanza NoConvertibleException antes de llamar al gateway.
-        assertThrows(NoConvertibleException.class,
-                () -> categoriaCursoServicio.insertarCategoria(null));
-
-        verifyNoInteractions(categoriaCursoGateway);
-    }
-
-    @Test
     void insertarCategoria_gatewayRetornaNull_lanzaInsercionFallidaExepcion() {
         when(categoriaCursoGateway.registrarCategoria(any(Categoria.class))).thenReturn(null);
 
         assertThrows(InsercionFallidaExepcion.class,
-                () -> categoriaCursoServicio.insertarCategoria(categoriaDto()));
+                () -> categoriaCursoServicio.insertarCategoria(categoriaModelo()));
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -114,27 +92,13 @@ class CategoriaCursoServicioTest {
     // ──────────────────────────────────────────────────────────────────────────
 
     @Test
-    void obtenerCategoriaCursoPorId_exitosa_retornaDtoMapeado() {
+    void obtenerCategoriaCursoPorId_exitosa_retornaCategoria() {
         when(categoriaCursoGateway.obtenerCategoria(TITULO)).thenReturn(categoriaModelo());
 
-        CategoriaDto resultado = categoriaCursoServicio.obtenerCategoriaCursoPorId(TITULO);
+        Categoria resultado = categoriaCursoServicio.obtenerCategoriaCursoPorId(TITULO);
 
         assertNotNull(resultado);
         assertEquals(TITULO, resultado.getTitulo());
-    }
-
-    @Test
-    void obtenerCategoriaCursoPorId_gatewayRetornaNull_lanzaErrorInterno_comportamientoActual() {
-        // COMPORTAMIENTO CUESTIONABLE (A): si la categoria no existe el gateway retorna null,
-        // la conversion a DTO falla silenciosamente, y el servicio lanza ErrorInternoException.
-        // Deberia lanzar NoExisteExcepcion (como hace actualizarCategoria con existeCategoria).
-        // Riesgo: el cliente recibe 500/error interno en vez de 404 cuando la categoria no existe.
-        when(categoriaCursoGateway.obtenerCategoria(TITULO)).thenReturn(null);
-
-        assertThrows(ErrorInternoException.class,
-                () -> categoriaCursoServicio.obtenerCategoriaCursoPorId(TITULO),
-                "obtenerCategoriaCursoPorId lanza ErrorInternoException cuando la categoria no existe " +
-                "en lugar de NoExisteExcepcion");
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -146,43 +110,32 @@ class CategoriaCursoServicioTest {
         when(categoriaCursoGateway.existeCategoria(TITULO)).thenReturn(false);
 
         assertThrows(NoExisteExcepcion.class,
-                () -> categoriaCursoServicio.actualizarCategoria(TITULO, categoriaDto()));
-
-        verify(categoriaCursoGateway, never()).actualizarCategoria(any(), any());
-    }
-
-    @Test
-    void actualizarCategoria_datosNulos_lanzaErrorInterno() {
-        // Categoria.fabricarDeDto(null) retorna null → el servicio lanza ErrorInternoException.
-        when(categoriaCursoGateway.existeCategoria(TITULO)).thenReturn(true);
-
-        assertThrows(ErrorInternoException.class,
-                () -> categoriaCursoServicio.actualizarCategoria(TITULO, null));
+                () -> categoriaCursoServicio.actualizarCategoria(TITULO, categoriaModelo()));
 
         verify(categoriaCursoGateway, never()).actualizarCategoria(any(), any());
     }
 
     @Test
     void actualizarCategoria_gatewayRetornaNull_retornaNullSinExcepcion_comportamientoActual() {
-        // COMPORTAMIENTO CUESTIONABLE (B): si el gateway retorna null, CategoriaDto.fabricarDeModelo(null)
-        // captura la NPE y retorna null silenciosamente. El servicio retorna null al caller
-        // sin lanzar excepcion. Inconsistente con insertarCategoria que si guarda contra null.
+        // COMPORTAMIENTO CUESTIONABLE (B): si el gateway retorna null, el servicio lo
+        // retorna directamente sin lanzar excepcion. Inconsistente con insertarCategoria
+        // que si guarda contra null. Documentado para que no pase como accidental.
         when(categoriaCursoGateway.existeCategoria(TITULO)).thenReturn(true);
         when(categoriaCursoGateway.actualizarCategoria(eq(TITULO), any(Categoria.class))).thenReturn(null);
 
-        CategoriaDto resultado = categoriaCursoServicio.actualizarCategoria(TITULO, categoriaDto());
+        Categoria resultado = categoriaCursoServicio.actualizarCategoria(TITULO, categoriaModelo());
 
         assertNull(resultado,
                 "actualizarCategoria retorna null sin excepcion cuando el gateway retorna null");
     }
 
     @Test
-    void actualizarCategoria_exitosa_retornaDtoMapeado() {
+    void actualizarCategoria_exitosa_retornaCategoria() {
         when(categoriaCursoGateway.existeCategoria(TITULO)).thenReturn(true);
         when(categoriaCursoGateway.actualizarCategoria(eq(TITULO), any(Categoria.class)))
                 .thenReturn(categoriaModelo());
 
-        CategoriaDto resultado = categoriaCursoServicio.actualizarCategoria(TITULO, categoriaDto());
+        Categoria resultado = categoriaCursoServicio.actualizarCategoria(TITULO, categoriaModelo());
 
         assertNotNull(resultado);
         assertEquals(TITULO, resultado.getTitulo());
@@ -194,36 +147,27 @@ class CategoriaCursoServicioTest {
     // ──────────────────────────────────────────────────────────────────────────
 
     @Test
-    void eliminarCategoria_exitosa_retornaDtoConEliminadoActualizado() {
+    void eliminarCategoria_exitosa_retornaCategoriaEliminada() {
         Categoria eliminada = categoriaModelo();
         eliminada.setEliminado(1);
         when(categoriaCursoGateway.eliminarCategoria(TITULO)).thenReturn(eliminada);
 
-        CategoriaDto resultado = categoriaCursoServicio.eliminarCategoria(TITULO);
+        Categoria resultado = categoriaCursoServicio.eliminarCategoria(TITULO);
 
         assertNotNull(resultado);
         assertEquals(TITULO, resultado.getTitulo());
+        assertEquals(1, resultado.getEliminado());
         verify(categoriaCursoGateway).eliminarCategoria(TITULO);
     }
 
     @Test
     void eliminarCategoria_gatewayLanzaNoExiste_propagaSinInterceptar() {
-        // El gateway es la autoridad: lanza NoExisteExcepcion (o YaExisteElementoExcepcion)
-        // directamente. El servicio no duplica la guarda con existeCategoria — deja propagar.
+        // El gateway es la autoridad: lanza NoExisteExcepcion directamente.
+        // El servicio no duplica la guarda — deja propagar.
         when(categoriaCursoGateway.eliminarCategoria(TITULO))
                 .thenThrow(new NoExisteExcepcion("No existe la categoria " + TITULO));
 
         assertThrows(NoExisteExcepcion.class,
-                () -> categoriaCursoServicio.eliminarCategoria(TITULO));
-    }
-
-    @Test
-    void eliminarCategoria_gatewayRetornaNull_lanzaErrorInterno() {
-        // Red de seguridad del servicio: si el gateway retorna null en vez de lanzar
-        // excepcion, el if(categoria==null) captura el caso y lanza ErrorInternoException.
-        when(categoriaCursoGateway.eliminarCategoria(TITULO)).thenReturn(null);
-
-        assertThrows(ErrorInternoException.class,
                 () -> categoriaCursoServicio.eliminarCategoria(TITULO));
     }
 }

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/CategoriaRestTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/CategoriaRestTest.java
@@ -1,0 +1,116 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.api;
+
+import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.ICategoriaCursoServicio;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Categoria;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.CategoriaDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class CategoriaRestTest {
+
+    @Mock
+    private ICategoriaCursoServicio servicioCategoria;
+
+    @InjectMocks
+    private CategoriaRest categoriaRest;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(categoriaRest)
+            .setMessageConverters(new MappingJackson2HttpMessageConverter())
+            .build();
+    }
+
+    private Categoria categoriaBase() {
+        Categoria c = new Categoria();
+        c.setTitulo("Acuatico");
+        c.setDescripcion("Deportes acuaticos");
+        c.setImagen(1);
+        c.setEliminado(0);
+        return c;
+    }
+
+    @Test
+    void obtenerCategoriasExistentes_retornaListaDto() throws Exception {
+        when(servicioCategoria.recuperarCategoriasCurso()).thenReturn(List.of(categoriaBase()));
+
+        mockMvc.perform(get("/api/v2/categorias2"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].titulo").value("Acuatico"))
+            .andExpect(jsonPath("$[0].descripcion").value("Deportes acuaticos"));
+    }
+
+    @Test
+    void obtenerCategoria_retornaDto() throws Exception {
+        when(servicioCategoria.obtenerCategoriaCursoPorId("Acuatico")).thenReturn(categoriaBase());
+
+        mockMvc.perform(get("/api/v2/categoria").param("titulo", "Acuatico"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.titulo").value("Acuatico"));
+    }
+
+    @Test
+    void postCategoria_retornaCreated() throws Exception {
+        when(servicioCategoria.insertarCategoria(any())).thenReturn(categoriaBase());
+
+        CategoriaDto dto = new CategoriaDto();
+        dto.setTitulo("Acuatico");
+        dto.setDescripcion("Deportes acuaticos");
+        dto.setImagenId(1);
+
+        mockMvc.perform(post("/api/v2/categoria")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.titulo").value("Acuatico"));
+    }
+
+    @Test
+    void putCategoria_retornaOk() throws Exception {
+        when(servicioCategoria.actualizarCategoria(eq("Acuatico"), any())).thenReturn(categoriaBase());
+
+        CategoriaDto dto = new CategoriaDto();
+        dto.setTitulo("Acuatico");
+        dto.setDescripcion("Deportes acuaticos actualizado");
+        dto.setImagenId(1);
+
+        mockMvc.perform(put("/api/v2/categoria")
+                .param("titulo", "Acuatico")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.titulo").value("Acuatico"));
+    }
+
+    @Test
+    void deleteCategoria_retornaOk() throws Exception {
+        Categoria eliminada = categoriaBase();
+        eliminada.setEliminado(1);
+        when(servicioCategoria.eliminarCategoria("Acuatico")).thenReturn(eliminada);
+
+        mockMvc.perform(delete("/api/v2/categoria").param("titulo", "Acuatico"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.titulo").value("Acuatico"));
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/CategoriaMapperTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/CategoriaMapperTest.java
@@ -1,0 +1,153 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.mappers;
+
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Categoria;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.CategoriaDto;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.CategoriaCursoEntidad;
+import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoProcesableEntidadException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CategoriaMapperTest {
+
+    private CategoriaCursoEntidad entidadBase() {
+        CategoriaCursoEntidad e = new CategoriaCursoEntidad();
+        e.setTitulo("Acuatico");
+        e.setDescripcion("Deportes acuaticos");
+        e.setCat_imagen(1);
+        e.setEliminado(0);
+        return e;
+    }
+
+    private Categoria categoriaBase() {
+        Categoria c = new Categoria();
+        c.setTitulo("Acuatico");
+        c.setDescripcion("Deportes acuaticos");
+        c.setImagen(1);
+        c.setEliminado(0);
+        return c;
+    }
+
+    private CategoriaDto dtoBase() {
+        CategoriaDto dto = new CategoriaDto();
+        dto.setTitulo("Acuatico");
+        dto.setDescripcion("Deportes acuaticos");
+        dto.setImagenId(1);
+        return dto;
+    }
+
+    // ── toDominio ──────────────────────────────────────────────────────────────
+
+    @Test
+    void toDominio_mapeaTodosLosCamposCorrectamente() {
+        CategoriaCursoEntidad entidad = entidadBase();
+        entidad.setEliminado(1);
+
+        Categoria resultado = CategoriaMapper.toDominio(entidad);
+
+        assertNotNull(resultado);
+        assertEquals("Acuatico", resultado.getTitulo());
+        assertEquals("Deportes acuaticos", resultado.getDescripcion());
+        assertEquals(1, resultado.getImagen());
+        assertEquals(1, resultado.getEliminado());
+    }
+
+    @Test
+    void toDominio_eliminadoCero_mapeaCorrectamente() {
+        CategoriaCursoEntidad entidad = entidadBase();
+        entidad.setEliminado(0);
+
+        Categoria resultado = CategoriaMapper.toDominio(entidad);
+
+        assertEquals(0, resultado.getEliminado());
+    }
+
+    // ── toDominio catch: return null silencioso ────────────────────────────────
+    // Documenta el comportamiento actual: captura cualquier excepcion y retorna
+    // null en lugar de propagarla — analogo a MapperImagen y CursoMapper.
+    // No es el diseno ideal, pero queda documentado para que no pase como accidental.
+
+    @Test
+    void toDominio_entidadNula_retornaNull() {
+        Categoria resultado = CategoriaMapper.toDominio(null);
+        assertNull(resultado);
+    }
+
+    // ── toEntidad ──────────────────────────────────────────────────────────────
+
+    @Test
+    void toEntidad_mapeaTodosLosCamposCorrectamente() {
+        Categoria categoria = categoriaBase();
+        categoria.setEliminado(0);
+
+        CategoriaCursoEntidad resultado = CategoriaMapper.toEntidad(categoria);
+
+        assertNotNull(resultado);
+        assertEquals("Acuatico", resultado.getTitulo());
+        assertEquals("Deportes acuaticos", resultado.getDescripcion());
+        assertEquals(Integer.valueOf(1), resultado.getCat_imagen());
+        assertEquals(0, resultado.getEliminado());
+    }
+
+    @Test
+    void toEntidad_eliminadoCero_porDefectoCuandoVieneDeDtoConversion() {
+        Categoria categoria = new Categoria();
+        categoria.setTitulo("Acuatico");
+        categoria.setDescripcion("Desc");
+        categoria.setImagen(1);
+        // eliminado no seteado: int default = 0
+
+        CategoriaCursoEntidad resultado = CategoriaMapper.toEntidad(categoria);
+
+        assertEquals(0, resultado.getEliminado());
+    }
+
+    // ── toEntidad catch: return null silencioso ────────────────────────────────
+
+    @Test
+    void toEntidad_categoriaNula_retornaNull() {
+        CategoriaCursoEntidad resultado = CategoriaMapper.toEntidad(null);
+        assertNull(resultado);
+    }
+
+    // ── toDto ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void toDto_mapeaTodosLosCamposCorrectamente() {
+        Categoria categoria = categoriaBase();
+
+        CategoriaDto resultado = CategoriaMapper.toDto(categoria);
+
+        assertNotNull(resultado);
+        assertEquals("Acuatico", resultado.getTitulo());
+        assertEquals("Deportes acuaticos", resultado.getDescripcion());
+        assertEquals(Integer.valueOf(1), resultado.getImagenId());
+    }
+
+    // ── toDto catch: return null silencioso ────────────────────────────────────
+
+    @Test
+    void toDto_categoriaNula_retornaNull() {
+        CategoriaDto resultado = CategoriaMapper.toDto(null);
+        assertNull(resultado);
+    }
+
+    // ── fromDto ────────────────────────────────────────────────────────────────
+
+    @Test
+    void fromDto_mapeaTodosLosCamposCorrectamente() {
+        CategoriaDto dto = dtoBase();
+
+        Categoria resultado = CategoriaMapper.fromDto(dto);
+
+        assertNotNull(resultado);
+        assertEquals("Acuatico", resultado.getTitulo());
+        assertEquals("Deportes acuaticos", resultado.getDescripcion());
+        assertEquals(1, resultado.getImagen());
+    }
+
+    @Test
+    void fromDto_nulo_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> CategoriaMapper.fromDto(null));
+    }
+}


### PR DESCRIPTION
Segundo modulo del refactor de arquitectura (H-01/H-02/H-05), 
replicando el patron validado en Curso. Categoria.java (dominio) 
ya no importa CategoriaDto ni CategoriaCursoEntidad -- se crea 
CategoriaMapper centralizando las 4 conversiones. 
ICategoriaCursoServicio y CategoriaCursoServicio ahora operan 100% 
con tipos de dominio.

Incluye tests de controller (CategoriaRestTest) planeados desde el 
inicio, no como ajuste posterior -- leccion aplicada de la ronda de 
Curso.

356/356 tests. Cobertura de New Code proyectada 90.9%, por encima 
del 80% requerido.