### PR TITLE
Refactor: Escenario ya no depende de código de base de datos ni de la API REST

### DIFF
--- a/src/main/java/co/edu/unicauca/deporteParaTodos/aplicacion/puertos/puertosEntrada/IEscenarioServicio.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/aplicacion/puertos/puertosEntrada/IEscenarioServicio.java
@@ -1,13 +1,13 @@
 package co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada;
 
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.EscenarioDto;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Escenario;
 
 import java.util.List;
 
 public interface IEscenarioServicio {
-    List<EscenarioDto> listarEscenarios();
-    EscenarioDto obtenerEscenario(Integer id);
-    EscenarioDto insertarEscenario(EscenarioDto dto);
-    EscenarioDto actualizarEscenario(Integer id, EscenarioDto dto);
-    EscenarioDto eliminarEscenario(Integer id);
+    List<Escenario> listarEscenarios();
+    Escenario obtenerEscenario(Integer id);
+    Escenario insertarEscenario(Escenario escenario);
+    Escenario actualizarEscenario(Integer id, Escenario escenario);
+    Escenario eliminarEscenario(Integer id);
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/modelo/Escenario.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/modelo/Escenario.java
@@ -1,7 +1,5 @@
 package co.edu.unicauca.deporteParaTodos.dominio.modelo;
 
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.EscenarioDto;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.EscenarioEntidad;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,33 +18,4 @@ public class Escenario {
     private boolean disponible;
     private Integer eliminado;
 
-    public static Escenario fabricarDeEntidad(EscenarioEntidad entidad) {
-        try {
-            Escenario escenario = new Escenario();
-            escenario.setId(entidad.getId());
-            escenario.setNombre(entidad.getNombre());
-            escenario.setDescripcion(entidad.getDescripcion());
-            escenario.setNumTribunas(entidad.getNumTribunas());
-            escenario.setDisponible(entidad.getDisponible() == 1);
-            escenario.setEliminado(entidad.getEliminado());
-            return escenario;
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    public static Escenario fabricarDeDto(EscenarioDto dto) {
-        try {
-            Escenario escenario = new Escenario();
-            escenario.setId(dto.getId());
-            escenario.setNombre(dto.getNombre());
-            escenario.setDescripcion(dto.getDescripcion());
-            escenario.setNumTribunas(dto.getNumTribunas() != null ? dto.getNumTribunas() : 0);
-            escenario.setDisponible(dto.getDisponible() != null ? dto.getDisponible() : true);
-            escenario.setEliminado(0);
-            return escenario;
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/EscenarioServicio.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/EscenarioServicio.java
@@ -3,14 +3,12 @@ package co.edu.unicauca.deporteParaTodos.dominio.servicios;
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.IEscenarioServicio;
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosSalida.IEscenarioGateway;
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Escenario;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.EscenarioDto;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.ListadoVacioExcepcion;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoExisteExcepcion;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.YaExisteElementoExcepcion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -20,51 +18,44 @@ public class EscenarioServicio implements IEscenarioServicio {
     private IEscenarioGateway escenarioGateway;
 
     @Override
-    public List<EscenarioDto> listarEscenarios() {
+    public List<Escenario> listarEscenarios() {
         List<Escenario> escenarios = escenarioGateway.listarEscenarios();
         if (escenarios.isEmpty()) {
             throw new ListadoVacioExcepcion("No se encontraron escenarios registrados");
         }
-        List<EscenarioDto> dtos = new ArrayList<>();
-        escenarios.forEach(e -> dtos.add(EscenarioDto.fabricarDeModelo(e)));
-        return dtos;
+        return escenarios;
     }
 
     @Override
-    public EscenarioDto obtenerEscenario(Integer id) {
+    public Escenario obtenerEscenario(Integer id) {
         if (!escenarioGateway.existeEscenario(id)) {
             throw new NoExisteExcepcion("El escenario con id " + id + " no existe");
         }
-        Escenario escenario = escenarioGateway.obtenerEscenario(id);
-        return EscenarioDto.fabricarDeModelo(escenario);
+        return escenarioGateway.obtenerEscenario(id);
     }
 
     @Override
-    public EscenarioDto insertarEscenario(EscenarioDto dto) {
-        if (escenarioGateway.existeEscenarioPorNombre(dto.getNombre())) {
-            throw new YaExisteElementoExcepcion("Ya existe un escenario con el nombre '" + dto.getNombre() + "'");
+    public Escenario insertarEscenario(Escenario escenario) {
+        if (escenarioGateway.existeEscenarioPorNombre(escenario.getNombre())) {
+            throw new YaExisteElementoExcepcion("Ya existe un escenario con el nombre '" + escenario.getNombre() + "'");
         }
-        Escenario escenario = Escenario.fabricarDeDto(dto);
-        Escenario guardado = escenarioGateway.insertarEscenario(escenario);
-        return EscenarioDto.fabricarDeModelo(guardado);
+        return escenarioGateway.insertarEscenario(escenario);
     }
 
     @Override
-    public EscenarioDto actualizarEscenario(Integer id, EscenarioDto dto) {
+    public Escenario actualizarEscenario(Integer id, Escenario escenario) {
         if (!escenarioGateway.existeEscenario(id)) {
             throw new NoExisteExcepcion("El escenario con id " + id + " no existe");
         }
         Escenario actual = escenarioGateway.obtenerEscenario(id);
-        if (!dto.getNombre().equals(actual.getNombre()) && escenarioGateway.existeEscenarioPorNombre(dto.getNombre())) {
-            throw new YaExisteElementoExcepcion("Ya existe otro escenario con el nombre '" + dto.getNombre() + "'");
+        if (!escenario.getNombre().equals(actual.getNombre()) && escenarioGateway.existeEscenarioPorNombre(escenario.getNombre())) {
+            throw new YaExisteElementoExcepcion("Ya existe otro escenario con el nombre '" + escenario.getNombre() + "'");
         }
-        Escenario datos = Escenario.fabricarDeDto(dto);
-        Escenario actualizado = escenarioGateway.actualizarEscenario(id, datos);
-        return EscenarioDto.fabricarDeModelo(actualizado);
+        return escenarioGateway.actualizarEscenario(id, escenario);
     }
 
     @Override
-    public EscenarioDto eliminarEscenario(Integer id) {
+    public Escenario eliminarEscenario(Integer id) {
         if (!escenarioGateway.existeEscenario(id)) {
             throw new NoExisteExcepcion("El escenario con id " + id + " no existe");
         }
@@ -72,7 +63,6 @@ public class EscenarioServicio implements IEscenarioServicio {
         if (actual.getEliminado() != null && actual.getEliminado() == 1) {
             throw new YaExisteElementoExcepcion("El escenario ya se encuentra eliminado");
         }
-        Escenario eliminado = escenarioGateway.eliminarEscenario(id);
-        return EscenarioDto.fabricarDeModelo(eliminado);
+        return escenarioGateway.eliminarEscenario(id);
     }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/DTOs/EscenarioDto.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/DTOs/EscenarioDto.java
@@ -1,6 +1,5 @@
 package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs;
 
-import co.edu.unicauca.deporteParaTodos.dominio.modelo.Escenario;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
@@ -26,17 +25,4 @@ public class EscenarioDto {
 
     private Boolean disponible;
 
-    public static EscenarioDto fabricarDeModelo(Escenario escenario) {
-        try {
-            EscenarioDto dto = new EscenarioDto();
-            dto.setId(escenario.getId());
-            dto.setNombre(escenario.getNombre());
-            dto.setDescripcion(escenario.getDescripcion());
-            dto.setNumTribunas(escenario.getNumTribunas());
-            dto.setDisponible(escenario.isDisponible());
-            return dto;
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/EscenarioRest.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/EscenarioRest.java
@@ -1,8 +1,10 @@
 package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.api;
 
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.IEscenarioServicio;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Escenario;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.EscenarioDto;
 import co.edu.unicauca.deporteParaTodos.infraestructura.logs.PeticionLogger;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.EscenarioMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("api/v2")
@@ -41,7 +44,8 @@ public class EscenarioRest {
     @GetMapping("/escenarios")
     public ResponseEntity<List<EscenarioDto>> listarEscenarios() {
         PeticionLogger.log(LOGGER, "GET", "/api/v2/escenarios", "sin datos");
-        List<EscenarioDto> respuesta = servicio.listarEscenarios();
+        List<EscenarioDto> respuesta = servicio.listarEscenarios()
+                .stream().map(EscenarioMapper::toDto).collect(Collectors.toList());
         return new ResponseEntity<>(respuesta, HttpStatus.OK);
     }
 
@@ -53,8 +57,8 @@ public class EscenarioRest {
     @GetMapping("/escenario")
     public ResponseEntity<EscenarioDto> obtenerEscenario(@RequestParam Integer prmId) {
         PeticionLogger.log(LOGGER, "GET", "/api/v2/escenario", "prmId=" + prmId);
-        EscenarioDto dto = servicio.obtenerEscenario(prmId);
-        return new ResponseEntity<>(dto, HttpStatus.OK);
+        Escenario escenario = servicio.obtenerEscenario(prmId);
+        return new ResponseEntity<>(EscenarioMapper.toDto(escenario), HttpStatus.OK);
     }
 
     @Operation(summary = "Registra un nuevo escenario en el sistema")
@@ -65,8 +69,8 @@ public class EscenarioRest {
     @PostMapping("/escenario")
     public ResponseEntity<EscenarioDto> insertarEscenario(@RequestBody @Valid EscenarioDto dto) {
         PeticionLogger.log(LOGGER, "POST", "/api/v2/escenario", dto);
-        EscenarioDto guardado = servicio.insertarEscenario(dto);
-        return new ResponseEntity<>(guardado, HttpStatus.CREATED);
+        Escenario guardado = servicio.insertarEscenario(EscenarioMapper.fromDto(dto));
+        return new ResponseEntity<>(EscenarioMapper.toDto(guardado), HttpStatus.CREATED);
     }
 
     @Operation(summary = "Actualiza los datos de un escenario")
@@ -80,8 +84,8 @@ public class EscenarioRest {
             @RequestParam Integer prmId,
             @RequestBody @Valid EscenarioDto dto) {
         PeticionLogger.log(LOGGER, "PUT", "/api/v2/escenario", "prmId=" + prmId);
-        EscenarioDto actualizado = servicio.actualizarEscenario(prmId, dto);
-        return new ResponseEntity<>(actualizado, HttpStatus.OK);
+        Escenario actualizado = servicio.actualizarEscenario(prmId, EscenarioMapper.fromDto(dto));
+        return new ResponseEntity<>(EscenarioMapper.toDto(actualizado), HttpStatus.OK);
     }
 
     @Operation(summary = "Eliminación lógica de un escenario (meta_eliminado=1)")
@@ -93,7 +97,7 @@ public class EscenarioRest {
     @DeleteMapping("/escenario")
     public ResponseEntity<EscenarioDto> eliminarEscenario(@RequestParam Integer prmId) {
         PeticionLogger.log(LOGGER, "DELETE", "/api/v2/escenario", "prmId=" + prmId);
-        EscenarioDto eliminado = servicio.eliminarEscenario(prmId);
-        return new ResponseEntity<>(eliminado, HttpStatus.OK);
+        Escenario eliminado = servicio.eliminarEscenario(prmId);
+        return new ResponseEntity<>(EscenarioMapper.toDto(eliminado), HttpStatus.OK);
     }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/entidades/EscenarioEntidad.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/entidades/EscenarioEntidad.java
@@ -1,6 +1,5 @@
 package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades;
 
-import co.edu.unicauca.deporteParaTodos.dominio.modelo.Escenario;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -42,18 +41,4 @@ public class EscenarioEntidad {
     @Column(name = "META_ELIMINADO")
     private Integer eliminado;
 
-    public static EscenarioEntidad fabricarDeModelo(Escenario escenario) {
-        try {
-            EscenarioEntidad entidad = new EscenarioEntidad();
-            entidad.setId(escenario.getId());
-            entidad.setNombre(escenario.getNombre());
-            entidad.setDescripcion(escenario.getDescripcion());
-            entidad.setNumTribunas(escenario.getNumTribunas());
-            entidad.setDisponible(escenario.isDisponible() ? 1 : 0);
-            entidad.setEliminado(escenario.getEliminado() != null ? escenario.getEliminado() : 0);
-            return entidad;
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/EscenarioGateway.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/EscenarioGateway.java
@@ -5,6 +5,7 @@ import co.edu.unicauca.deporteParaTodos.dominio.modelo.Escenario;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.EscenarioEntidad;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.repositorios.IEscenarioRepositorio;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoExisteExcepcion;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.EscenarioMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -22,7 +23,7 @@ public class EscenarioGateway implements IEscenarioGateway {
     public List<Escenario> listarEscenarios() {
         List<EscenarioEntidad> entidades = repoEscenario.findByEliminado(0);
         List<Escenario> escenarios = new ArrayList<>();
-        entidades.forEach(entidad -> escenarios.add(Escenario.fabricarDeEntidad(entidad)));
+        entidades.forEach(entidad -> escenarios.add(EscenarioMapper.toDominio(entidad)));
         return escenarios;
     }
 
@@ -32,7 +33,7 @@ public class EscenarioGateway implements IEscenarioGateway {
         if (op.isEmpty()) {
             throw new NoExisteExcepcion("El escenario con id " + id + " no existe");
         }
-        return Escenario.fabricarDeEntidad(op.get());
+        return EscenarioMapper.toDominio(op.get());
     }
 
     @Override
@@ -47,10 +48,10 @@ public class EscenarioGateway implements IEscenarioGateway {
 
     @Override
     public Escenario insertarEscenario(Escenario escenario) {
-        EscenarioEntidad entidad = EscenarioEntidad.fabricarDeModelo(escenario);
+        EscenarioEntidad entidad = EscenarioMapper.toEntidad(escenario);
         entidad.setEliminado(0);
         EscenarioEntidad guardado = repoEscenario.save(entidad);
-        return Escenario.fabricarDeEntidad(guardado);
+        return EscenarioMapper.toDominio(guardado);
     }
 
     @Override
@@ -65,7 +66,7 @@ public class EscenarioGateway implements IEscenarioGateway {
         entidad.setNumTribunas(escenario.getNumTribunas());
         entidad.setDisponible(escenario.isDisponible() ? 1 : 0);
         EscenarioEntidad guardado = repoEscenario.save(entidad);
-        return Escenario.fabricarDeEntidad(guardado);
+        return EscenarioMapper.toDominio(guardado);
     }
 
     @Override
@@ -77,6 +78,6 @@ public class EscenarioGateway implements IEscenarioGateway {
         EscenarioEntidad entidad = op.get();
         entidad.setEliminado(1);
         EscenarioEntidad guardado = repoEscenario.save(entidad);
-        return Escenario.fabricarDeEntidad(guardado);
+        return EscenarioMapper.toDominio(guardado);
     }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/EscenarioMapper.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/EscenarioMapper.java
@@ -1,0 +1,68 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.mappers;
+
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Escenario;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.EscenarioDto;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.EscenarioEntidad;
+import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoProcesableEntidadException;
+
+public class EscenarioMapper {
+
+    public static Escenario toDominio(EscenarioEntidad entidad) {
+        try {
+            Escenario escenario = new Escenario();
+            escenario.setId(entidad.getId());
+            escenario.setNombre(entidad.getNombre());
+            escenario.setDescripcion(entidad.getDescripcion());
+            escenario.setNumTribunas(entidad.getNumTribunas());
+            escenario.setDisponible(entidad.getDisponible() == 1);
+            escenario.setEliminado(entidad.getEliminado());
+            return escenario;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static EscenarioEntidad toEntidad(Escenario escenario) {
+        try {
+            EscenarioEntidad entidad = new EscenarioEntidad();
+            entidad.setId(escenario.getId());
+            entidad.setNombre(escenario.getNombre());
+            entidad.setDescripcion(escenario.getDescripcion());
+            entidad.setNumTribunas(escenario.getNumTribunas());
+            entidad.setDisponible(escenario.isDisponible() ? 1 : 0);
+            entidad.setEliminado(escenario.getEliminado() != null ? escenario.getEliminado() : 0);
+            return entidad;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static EscenarioDto toDto(Escenario escenario) {
+        try {
+            EscenarioDto dto = new EscenarioDto();
+            dto.setId(escenario.getId());
+            dto.setNombre(escenario.getNombre());
+            dto.setDescripcion(escenario.getDescripcion());
+            dto.setNumTribunas(escenario.getNumTribunas());
+            dto.setDisponible(escenario.isDisponible());
+            return dto;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static Escenario fromDto(EscenarioDto dto) {
+        try {
+            Escenario escenario = new Escenario();
+            escenario.setId(dto.getId());
+            escenario.setNombre(dto.getNombre());
+            escenario.setDescripcion(dto.getDescripcion());
+            escenario.setNumTribunas(dto.getNumTribunas() != null ? dto.getNumTribunas() : 0);
+            escenario.setDisponible(dto.getDisponible() != null ? dto.getDisponible() : true);
+            escenario.setEliminado(0);
+            return escenario;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir EscenarioDto a dominio: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/EscenarioServicioTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/EscenarioServicioTest.java
@@ -2,7 +2,6 @@ package co.edu.unicauca.deporteParaTodos.dominio.servicios;
 
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosSalida.IEscenarioGateway;
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Escenario;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.EscenarioDto;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.ListadoVacioExcepcion;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoExisteExcepcion;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.YaExisteElementoExcepcion;
@@ -48,22 +47,13 @@ class EscenarioServicioTest {
         return e;
     }
 
-    private EscenarioDto dtoBase() {
-        EscenarioDto dto = new EscenarioDto();
-        dto.setNombre(NOMBRE);
-        dto.setDescripcion("Natación.");
-        dto.setNumTribunas(0);
-        dto.setDisponible(true);
-        return dto;
-    }
-
     // --- listarEscenarios ---
 
     @Test
-    void listarEscenarios_exitoso_retornaListaDtos() {
+    void listarEscenarios_exitoso_retornaListaEscenarios() {
         when(escenarioGateway.listarEscenarios()).thenReturn(List.of(escenarioActivo()));
 
-        List<EscenarioDto> resultado = escenarioServicio.listarEscenarios();
+        List<Escenario> resultado = escenarioServicio.listarEscenarios();
 
         assertEquals(1, resultado.size());
         assertEquals(NOMBRE, resultado.get(0).getNombre());
@@ -80,11 +70,11 @@ class EscenarioServicioTest {
     // --- obtenerEscenario ---
 
     @Test
-    void obtenerEscenario_exitoso_retornaDto() {
+    void obtenerEscenario_exitoso_retornaEscenario() {
         when(escenarioGateway.existeEscenario(ID)).thenReturn(true);
         when(escenarioGateway.obtenerEscenario(ID)).thenReturn(escenarioActivo());
 
-        EscenarioDto resultado = escenarioServicio.obtenerEscenario(ID);
+        Escenario resultado = escenarioServicio.obtenerEscenario(ID);
 
         assertNotNull(resultado);
         assertEquals(NOMBRE, resultado.getNombre());
@@ -103,11 +93,11 @@ class EscenarioServicioTest {
     // --- insertarEscenario ---
 
     @Test
-    void insertarEscenario_exitoso_retornaDto() {
+    void insertarEscenario_exitoso_retornaEscenario() {
         when(escenarioGateway.existeEscenarioPorNombre(NOMBRE)).thenReturn(false);
         when(escenarioGateway.insertarEscenario(any())).thenReturn(escenarioActivo());
 
-        EscenarioDto resultado = escenarioServicio.insertarEscenario(dtoBase());
+        Escenario resultado = escenarioServicio.insertarEscenario(escenarioActivo());
 
         assertNotNull(resultado);
         assertEquals(NOMBRE, resultado.getNombre());
@@ -118,7 +108,8 @@ class EscenarioServicioTest {
     void insertarEscenario_yaExiste_lanzaYaExisteElementoExcepcion() {
         when(escenarioGateway.existeEscenarioPorNombre(NOMBRE)).thenReturn(true);
 
-        assertThrows(YaExisteElementoExcepcion.class, () -> escenarioServicio.insertarEscenario(dtoBase()));
+        assertThrows(YaExisteElementoExcepcion.class,
+                () -> escenarioServicio.insertarEscenario(escenarioActivo()));
 
         verify(escenarioGateway, never()).insertarEscenario(any());
     }
@@ -126,7 +117,7 @@ class EscenarioServicioTest {
     // --- actualizarEscenario ---
 
     @Test
-    void actualizarEscenario_exitoso_retornaDto() {
+    void actualizarEscenario_exitoso_retornaEscenario() {
         Escenario actualizado = escenarioActivo();
         actualizado.setDescripcion("Nueva descripción");
 
@@ -134,7 +125,7 @@ class EscenarioServicioTest {
         when(escenarioGateway.obtenerEscenario(ID)).thenReturn(escenarioActivo());
         when(escenarioGateway.actualizarEscenario(eq(ID), any())).thenReturn(actualizado);
 
-        EscenarioDto resultado = escenarioServicio.actualizarEscenario(ID, dtoBase());
+        Escenario resultado = escenarioServicio.actualizarEscenario(ID, escenarioActivo());
 
         assertNotNull(resultado);
         assertEquals(NOMBRE, resultado.getNombre());
@@ -145,24 +136,25 @@ class EscenarioServicioTest {
     void actualizarEscenario_noExiste_lanzaNoExisteExcepcion() {
         when(escenarioGateway.existeEscenario(ID)).thenReturn(false);
 
-        assertThrows(NoExisteExcepcion.class, () -> escenarioServicio.actualizarEscenario(ID, dtoBase()));
+        assertThrows(NoExisteExcepcion.class,
+                () -> escenarioServicio.actualizarEscenario(ID, escenarioActivo()));
 
         verify(escenarioGateway, never()).actualizarEscenario(any(), any());
     }
 
     @Test
     void actualizarEscenario_nombreDuplicado_lanzaYaExisteElementoExcepcion() {
-        EscenarioDto dtoNuevoNombre = dtoBase();
-        dtoNuevoNombre.setNombre("Coliseo Cubierto Universitario");
+        Escenario datosNuevoNombre = escenarioActivo();
+        datosNuevoNombre.setNombre("Coliseo Cubierto Universitario");
 
-        Escenario actual = escenarioActivo(); // tiene nombre "Piscina Olímpica"
+        Escenario actual = escenarioActivo(); // nombre "Piscina Olímpica"
 
         when(escenarioGateway.existeEscenario(ID)).thenReturn(true);
         when(escenarioGateway.obtenerEscenario(ID)).thenReturn(actual);
         when(escenarioGateway.existeEscenarioPorNombre("Coliseo Cubierto Universitario")).thenReturn(true);
 
         assertThrows(YaExisteElementoExcepcion.class,
-            () -> escenarioServicio.actualizarEscenario(ID, dtoNuevoNombre));
+                () -> escenarioServicio.actualizarEscenario(ID, datosNuevoNombre));
 
         verify(escenarioGateway, never()).actualizarEscenario(any(), any());
     }
@@ -170,16 +162,17 @@ class EscenarioServicioTest {
     // --- eliminarEscenario ---
 
     @Test
-    void eliminarEscenario_exitoso_retornaDto() {
+    void eliminarEscenario_exitoso_retornaEscenarioEliminado() {
         Escenario eliminado = escenarioEliminado();
 
         when(escenarioGateway.existeEscenario(ID)).thenReturn(true);
         when(escenarioGateway.obtenerEscenario(ID)).thenReturn(escenarioActivo());
         when(escenarioGateway.eliminarEscenario(ID)).thenReturn(eliminado);
 
-        EscenarioDto resultado = escenarioServicio.eliminarEscenario(ID);
+        Escenario resultado = escenarioServicio.eliminarEscenario(ID);
 
         assertNotNull(resultado);
+        assertEquals(1, resultado.getEliminado());
         verify(escenarioGateway).eliminarEscenario(ID);
     }
 
@@ -197,7 +190,8 @@ class EscenarioServicioTest {
         when(escenarioGateway.existeEscenario(ID)).thenReturn(true);
         when(escenarioGateway.obtenerEscenario(ID)).thenReturn(escenarioEliminado());
 
-        assertThrows(YaExisteElementoExcepcion.class, () -> escenarioServicio.eliminarEscenario(ID));
+        assertThrows(YaExisteElementoExcepcion.class,
+                () -> escenarioServicio.eliminarEscenario(ID));
 
         verify(escenarioGateway, never()).eliminarEscenario(any());
     }

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/EscenarioRestTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/EscenarioRestTest.java
@@ -1,0 +1,122 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.api;
+
+import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.IEscenarioServicio;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Escenario;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.EscenarioDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class EscenarioRestTest {
+
+    @Mock
+    private IEscenarioServicio servicio;
+
+    @InjectMocks
+    private EscenarioRest escenarioRest;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(escenarioRest)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+    }
+
+    private Escenario escenarioBase() {
+        Escenario e = new Escenario();
+        e.setId(1);
+        e.setNombre("Piscina Olímpica");
+        e.setDescripcion("Natación competitiva.");
+        e.setNumTribunas(4);
+        e.setDisponible(true);
+        e.setEliminado(0);
+        return e;
+    }
+
+    @Test
+    void listarEscenarios_retornaListaDto() throws Exception {
+        when(servicio.listarEscenarios()).thenReturn(List.of(escenarioBase()));
+
+        mockMvc.perform(get("/api/v2/escenarios"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].nombre").value("Piscina Olímpica"))
+                .andExpect(jsonPath("$[0].numTribunas").value(4))
+                .andExpect(jsonPath("$[0].disponible").value(true));
+    }
+
+    @Test
+    void obtenerEscenario_retornaDto() throws Exception {
+        when(servicio.obtenerEscenario(1)).thenReturn(escenarioBase());
+
+        mockMvc.perform(get("/api/v2/escenario").param("prmId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nombre").value("Piscina Olímpica"))
+                .andExpect(jsonPath("$.id").value(1));
+    }
+
+    @Test
+    void postEscenario_retornaCreated() throws Exception {
+        when(servicio.insertarEscenario(any(Escenario.class))).thenReturn(escenarioBase());
+
+        EscenarioDto dto = new EscenarioDto();
+        dto.setNombre("Piscina Olímpica");
+        dto.setDescripcion("Natación competitiva.");
+        dto.setNumTribunas(4);
+        dto.setDisponible(true);
+
+        mockMvc.perform(post("/api/v2/escenario")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.nombre").value("Piscina Olímpica"));
+    }
+
+    @Test
+    void putEscenario_retornaOk() throws Exception {
+        when(servicio.actualizarEscenario(eq(1), any(Escenario.class))).thenReturn(escenarioBase());
+
+        EscenarioDto dto = new EscenarioDto();
+        dto.setNombre("Piscina Olímpica");
+        dto.setDescripcion("Actualizado.");
+        dto.setNumTribunas(6);
+        dto.setDisponible(true);
+
+        mockMvc.perform(put("/api/v2/escenario")
+                        .param("prmId", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nombre").value("Piscina Olímpica"));
+    }
+
+    @Test
+    void deleteEscenario_retornaOk() throws Exception {
+        Escenario eliminado = escenarioBase();
+        eliminado.setEliminado(1);
+        when(servicio.eliminarEscenario(1)).thenReturn(eliminado);
+
+        mockMvc.perform(delete("/api/v2/escenario").param("prmId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nombre").value("Piscina Olímpica"));
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/EscenarioMapperTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/EscenarioMapperTest.java
@@ -1,0 +1,178 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.mappers;
+
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Escenario;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.EscenarioDto;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.EscenarioEntidad;
+import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoProcesableEntidadException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EscenarioMapperTest {
+
+    private EscenarioEntidad entidadBase() {
+        EscenarioEntidad e = new EscenarioEntidad();
+        e.setId(1);
+        e.setNombre("Piscina Olímpica");
+        e.setDescripcion("Natación competitiva.");
+        e.setNumTribunas(4);
+        e.setDisponible(1);
+        e.setEliminado(0);
+        return e;
+    }
+
+    private Escenario escenarioBase() {
+        Escenario e = new Escenario();
+        e.setId(1);
+        e.setNombre("Piscina Olímpica");
+        e.setDescripcion("Natación competitiva.");
+        e.setNumTribunas(4);
+        e.setDisponible(true);
+        e.setEliminado(0);
+        return e;
+    }
+
+    private EscenarioDto dtoBase() {
+        EscenarioDto dto = new EscenarioDto();
+        dto.setId(1);
+        dto.setNombre("Piscina Olímpica");
+        dto.setDescripcion("Natación competitiva.");
+        dto.setNumTribunas(4);
+        dto.setDisponible(true);
+        return dto;
+    }
+
+    // ── toDominio ──────────────────────────────────────────────────────────────
+
+    @Test
+    void toDominio_disponibleUno_retornaTrue_mapeaTodosCampos() {
+        EscenarioEntidad entidad = entidadBase();
+        entidad.setDisponible(1);
+
+        Escenario resultado = EscenarioMapper.toDominio(entidad);
+
+        assertNotNull(resultado);
+        assertEquals(1, resultado.getId());
+        assertEquals("Piscina Olímpica", resultado.getNombre());
+        assertEquals("Natación competitiva.", resultado.getDescripcion());
+        assertEquals(4, resultado.getNumTribunas());
+        assertTrue(resultado.isDisponible(), "disponible == 1 debe mapear a true");
+        assertEquals(0, resultado.getEliminado());
+    }
+
+    @Test
+    void toDominio_disponibleCero_retornaFalse() {
+        EscenarioEntidad entidad = entidadBase();
+        entidad.setDisponible(0);
+
+        Escenario resultado = EscenarioMapper.toDominio(entidad);
+
+        assertFalse(resultado.isDisponible(), "disponible == 0 debe mapear a false (no != 0)");
+    }
+
+    // ── toDominio catch: return null silencioso ────────────────────────────────
+    // Documenta el comportamiento actual: captura cualquier excepcion y retorna
+    // null en lugar de propagarla — analogo a CursoMapper y CategoriaMapper.
+    // No es el diseno ideal, pero queda documentado para que no pase como accidental.
+
+    @Test
+    void toDominio_entidadNula_retornaNull() {
+        Escenario resultado = EscenarioMapper.toDominio(null);
+        assertNull(resultado);
+    }
+
+    // ── toEntidad ──────────────────────────────────────────────────────────────
+
+    @Test
+    void toEntidad_disponibleTrue_mapea1_mapeaTodosCampos() {
+        Escenario escenario = escenarioBase();
+        escenario.setDisponible(true);
+
+        EscenarioEntidad resultado = EscenarioMapper.toEntidad(escenario);
+
+        assertNotNull(resultado);
+        assertEquals(1, resultado.getId());
+        assertEquals("Piscina Olímpica", resultado.getNombre());
+        assertEquals("Natación competitiva.", resultado.getDescripcion());
+        assertEquals(4, resultado.getNumTribunas());
+        assertEquals(1, resultado.getDisponible(), "disponible true debe mapear a 1");
+        assertEquals(0, resultado.getEliminado());
+    }
+
+    @Test
+    void toEntidad_disponibleFalse_mapea0() {
+        Escenario escenario = escenarioBase();
+        escenario.setDisponible(false);
+
+        EscenarioEntidad resultado = EscenarioMapper.toEntidad(escenario);
+
+        assertEquals(0, resultado.getDisponible(), "disponible false debe mapear a 0 (ternario ? 1 : 0)");
+    }
+
+    // ── toEntidad catch: return null silencioso ────────────────────────────────
+
+    @Test
+    void toEntidad_escenarioNulo_retornaNull() {
+        EscenarioEntidad resultado = EscenarioMapper.toEntidad(null);
+        assertNull(resultado);
+    }
+
+    // ── toDto ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void toDto_mapeaTodosLosCamposCorrectamente() {
+        Escenario escenario = escenarioBase();
+
+        EscenarioDto resultado = EscenarioMapper.toDto(escenario);
+
+        assertNotNull(resultado);
+        assertEquals(1, resultado.getId());
+        assertEquals("Piscina Olímpica", resultado.getNombre());
+        assertEquals("Natación competitiva.", resultado.getDescripcion());
+        assertEquals(Integer.valueOf(4), resultado.getNumTribunas());
+        assertTrue(resultado.getDisponible());
+    }
+
+    // ── toDto catch: return null silencioso ────────────────────────────────────
+
+    @Test
+    void toDto_escenarioNulo_retornaNull() {
+        EscenarioDto resultado = EscenarioMapper.toDto(null);
+        assertNull(resultado);
+    }
+
+    // ── fromDto ────────────────────────────────────────────────────────────────
+
+    @Test
+    void fromDto_mapeaTodosLosCamposCorrectamente() {
+        EscenarioDto dto = dtoBase();
+
+        Escenario resultado = EscenarioMapper.fromDto(dto);
+
+        assertNotNull(resultado);
+        assertEquals(1, resultado.getId());
+        assertEquals("Piscina Olímpica", resultado.getNombre());
+        assertEquals("Natación competitiva.", resultado.getDescripcion());
+        assertEquals(4, resultado.getNumTribunas());
+        assertTrue(resultado.isDisponible());
+        assertEquals(0, resultado.getEliminado());
+    }
+
+    @Test
+    void fromDto_camposNulos_aplicaDefaultsNullSafe() {
+        EscenarioDto dto = new EscenarioDto();
+        dto.setNombre("Coliseo");
+        // numTribunas y disponible son null
+
+        Escenario resultado = EscenarioMapper.fromDto(dto);
+
+        assertEquals(0, resultado.getNumTribunas(), "numTribunas null debe defecto a 0");
+        assertTrue(resultado.isDisponible(), "disponible null debe defecto a true");
+        assertEquals(0, resultado.getEliminado(), "eliminado siempre 0 para registros nuevos");
+    }
+
+    @Test
+    void fromDto_nulo_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> EscenarioMapper.fromDto(null));
+    }
+}


### PR DESCRIPTION
Tercer modulo del refactor de arquitectura (H-01/H-02/H-05), 
replicando el patron validado en Curso y Categoria. Escenario.java 
(dominio) ya no importa EscenarioDto ni EscenarioEntidad -- se crea 
EscenarioMapper centralizando las 4 conversiones, incluyendo la 
conversion cuidadosa de disponible (int en entidad, boolean en 
dominio). IEscenarioServicio y EscenarioServicio ahora operan 100% 
con tipos de dominio.

Incluye tests de controller (EscenarioRestTest) planeados desde el 
inicio. 28 tests nuevos/actualizados de Escenario. Cobertura de New 
Code proyectada 92.0%, por encima del 80% requerido.