### PR TITLE
Clase ya no depende de código de base de datos ni de la API REST

### DIFF
--- a/src/main/java/co/edu/unicauca/deporteParaTodos/aplicacion/puertos/puertosEntrada/IClaseServicio.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/aplicacion/puertos/puertosEntrada/IClaseServicio.java
@@ -1,12 +1,12 @@
 package co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada;
 
 import java.util.List;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.ClaseDto;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Clase;
 
 public interface IClaseServicio {
-    public List<ClaseDto> obtenerClasesGrupo(String categoria, String curso, Integer anio, Integer iterable);
+    public List<Clase> obtenerClasesGrupo(String categoria, String curso, Integer anio, Integer iterable);
 
-    public ClaseDto insertarClase(ClaseDto datoClase);
+    public Clase insertarClase(Clase datoClase);
 
-    public ClaseDto eliminarClase(int id);
+    public Clase eliminarClase(int id);
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/modelo/Clase.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/modelo/Clase.java
@@ -2,8 +2,6 @@ package co.edu.unicauca.deporteParaTodos.dominio.modelo;
 
 import java.sql.Date;
 
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.ClaseDto;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.ClaseEntidad;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,44 +34,4 @@ public class Clase {
     private String observacion;
 
     private Integer eliminado;
-
-    public static Clase fabricarDeEntidad(ClaseEntidad entidad) {
-        try {
-            Clase modelo = new Clase();
-            modelo.setCodigo(entidad.getCodigo());
-            modelo.setCategoria(entidad.getIdGrupoCategoria());
-            modelo.setCurso(entidad.getIdGrupoCurso());
-            modelo.setAnio(entidad.getIdGrupoAnio());
-            modelo.setIterable(entidad.getIdGrupoIterable());
-            modelo.setIdInstructor(entidad.getIdInstructor());
-            modelo.setFecha(entidad.getFecha());
-            modelo.setHoras(entidad.getHoras());
-            modelo.setMinutos(entidad.getMinutos());
-            modelo.setObservacion(entidad.getObservacion());
-            modelo.setEliminado(entidad.getEliminado());
-            return modelo;
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    public static Clase fabricarDeDto(ClaseDto dto) {
-        try {
-            Clase modelo = new Clase();
-            modelo.setCodigo(dto.getCodigo());
-            modelo.setCategoria(dto.getCategoria());
-            modelo.setCurso(dto.getCurso());
-            modelo.setAnio(dto.getAnio());
-            modelo.setIterable(dto.getIterable());
-            modelo.setIdInstructor(dto.getIdInstructor());
-            modelo.setFecha(dto.getFecha());
-            modelo.setHoras(dto.getHoras());
-            modelo.setMinutos(dto.getMinutos());
-            modelo.setObservacion(dto.getObservacion());
-            modelo.setEliminado(dto.getEliminado());
-            return modelo;
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/ClaseServicio.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/ClaseServicio.java
@@ -1,14 +1,11 @@
 package co.edu.unicauca.deporteParaTodos.dominio.servicios;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.IClaseServicio;
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosSalida.IClaseGateway;
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Clase;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.ClaseDto;
-import co.edu.unicauca.deporteParaTodos.dominio.excepciones.ErrorInternoException;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.ListadoVacioExcepcion;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
 
@@ -19,44 +16,24 @@ public class ClaseServicio implements IClaseServicio {
     private IClaseGateway claseGateway;
 
     @Override
-    public List<ClaseDto> obtenerClasesGrupo(String categoria, String curso, Integer anio, Integer iterable) {
+    public List<Clase> obtenerClasesGrupo(String categoria, String curso, Integer anio, Integer iterable) {
         List<Clase> listado = claseGateway.obtenerClasesGrupo(categoria, curso, anio, iterable);
         if (listado.isEmpty()) {
             throw new ListadoVacioExcepcion("No existen registros");
         }
-        List<ClaseDto> listaDtos = new ArrayList<>();
-        listado.forEach(modelo -> {
-            ClaseDto dto = ClaseDto.fabricarDeModelo(modelo);
-            listaDtos.add(dto);
-        });
-        return listaDtos;
+        return listado;
     }
 
     @Override
-    public ClaseDto insertarClase(ClaseDto datoClase) {
-        Clase modelo = Clase.fabricarDeDto(datoClase);
-        if (modelo == null) {
-            throw new ErrorInternoException();
-        }
-        Clase claseInsertada = claseGateway.insertarClase(modelo);
-        ClaseDto respuesta = ClaseDto.fabricarDeModelo(claseInsertada);
-        if (respuesta == null) {
-            throw new ErrorInternoException();
-        }
-        return respuesta;
+    public Clase insertarClase(Clase datoClase) {
+        return claseGateway.insertarClase(datoClase);
     }
 
     @Override
-    public ClaseDto eliminarClase(int id) {
+    public Clase eliminarClase(int id) {
         if (!claseGateway.existeClase(id)) {
             throw new NoExisteExcepcion();
         }
-        Clase claseEliminada = claseGateway.eliminarClase(id);
-        ClaseDto respuesta = ClaseDto.fabricarDeModelo(claseEliminada);
-        if (respuesta == null) {
-            throw new ErrorInternoException();
-        }
-        return respuesta;
+        return claseGateway.eliminarClase(id);
     }
-
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/DTOs/ClaseDto.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/DTOs/ClaseDto.java
@@ -2,7 +2,6 @@ package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadores
 
 import java.sql.Date;
 
-import co.edu.unicauca.deporteParaTodos.dominio.modelo.Clase;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
@@ -55,24 +54,4 @@ public class ClaseDto {
     private String observacion;
 
     private Integer eliminado;
-
-    public static ClaseDto fabricarDeModelo(Clase modelo) {
-        try {
-            ClaseDto dto = new ClaseDto();
-            dto.setCodigo(modelo.getCodigo());
-            dto.setCategoria(modelo.getCategoria());
-            dto.setCurso(modelo.getCurso());
-            dto.setAnio(modelo.getAnio());
-            dto.setIterable(modelo.getIterable());
-            dto.setIdInstructor(modelo.getIdInstructor());
-            dto.setFecha(modelo.getFecha());
-            dto.setHoras(modelo.getHoras());
-            dto.setMinutos(modelo.getMinutos());
-            dto.setObservacion(modelo.getObservacion());
-            dto.setEliminado(modelo.getEliminado());
-            return dto;
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/ClaseRest.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/ClaseRest.java
@@ -1,6 +1,7 @@
 package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.api;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,8 +14,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.IClaseServicio;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Clase;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.ClaseDto;
 import co.edu.unicauca.deporteParaTodos.infraestructura.logs.PeticionLogger;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.ClaseMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -25,7 +28,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-
 
 
 @RestController
@@ -55,7 +57,9 @@ public class ClaseRest {
             @RequestParam Integer iterable) {
         PeticionLogger.log(LOGGER, "GET", "/api/v2/clasesGrupo",
                 "categoria=" + categoria + ", curso=" + curso + ", anio=" + anio + ", iterable=" + iterable);
-        List<ClaseDto> respuesta = servicioClase.obtenerClasesGrupo(categoria, curso, anio, iterable);
+        List<ClaseDto> respuesta = servicioClase.obtenerClasesGrupo(categoria, curso, anio, iterable).stream()
+                .map(ClaseMapper::toDto)
+                .collect(Collectors.toList());
         return new ResponseEntity<>(respuesta, HttpStatus.OK);
     }
 
@@ -66,16 +70,11 @@ public class ClaseRest {
     @PostMapping("/claseGrupo")
     public ResponseEntity<ClaseDto> postClase(@RequestBody @Valid ClaseDto entidad) {
         PeticionLogger.log(LOGGER, "POST", "/api/v2/claseGrupo", entidad);
-        ClaseDto respuesta = servicioClase.insertarClase(entidad);
-        return new ResponseEntity<>(respuesta,HttpStatus.CREATED);
-        
+        Clase modelo = ClaseMapper.fromDto(entidad);
+        Clase claseInsertada = servicioClase.insertarClase(modelo);
+        return new ResponseEntity<>(ClaseMapper.toDto(claseInsertada), HttpStatus.CREATED);
     }
 
-    /***
-     * Cambia el estado eliminado de la clase a 1, para marcar como eliminada
-     * @param id
-     * @return
-     */
     @Operation(summary = "Marca una clase como eliminada")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Clase eliminada logicamente"),
@@ -84,11 +83,9 @@ public class ClaseRest {
     @DeleteMapping("/clase")
     public ResponseEntity<ClaseDto> deleteClase(
             @Parameter(description = "Codigo de la clase a eliminar")
-            @RequestParam @NotNull Integer id){
+            @RequestParam @NotNull Integer id) {
         PeticionLogger.log(LOGGER, "DELETE", "/api/v2/clase", "id=" + id);
-        ClaseDto respuesta = servicioClase.eliminarClase(id);
-        return new ResponseEntity<>(respuesta, HttpStatus.OK);
+        Clase claseEliminada = servicioClase.eliminarClase(id);
+        return new ResponseEntity<>(ClaseMapper.toDto(claseEliminada), HttpStatus.OK);
     }
-    
-    
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/ClaseGateway.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/ClaseGateway.java
@@ -1,7 +1,7 @@
 package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.gateway;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -10,6 +10,7 @@ import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosSalida.IClaseG
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Clase;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.ClaseEntidad;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.repositorios.IClaseRepositorio;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.ClaseMapper;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
 
 @Service
@@ -28,32 +29,18 @@ public class ClaseGateway implements IClaseGateway {
         List<ClaseEntidad> entidades = repoClase
                 .findByIdGrupoCategoriaAndIdGrupoCursoAndIdGrupoAnioAndIdGrupoIterableAndEliminado(
                         categoria, curso, anio, iterable, 0);
-        List<Clase> listado = new ArrayList<>();
-        entidades.forEach(entidad -> {
-            Clase modelo = Clase.fabricarDeEntidad(entidad);
-            if (modelo != null) {
-                listado.add(modelo);
-            }
-        });
-        return listado;
+        return entidades.stream()
+                .map(ClaseMapper::toDominio)
+                .collect(Collectors.toList());
     }
 
     @Override
     public Clase insertarClase(Clase datoClase) {
-        ClaseEntidad entidad = new ClaseEntidad();
+        ClaseEntidad entidad = ClaseMapper.toEntidad(datoClase);
         entidad.setCodigo(null);
-        entidad.setIdGrupoCategoria(datoClase.getCategoria());
-        entidad.setIdGrupoCurso(datoClase.getCurso());
-        entidad.setIdGrupoAnio(datoClase.getAnio());
-        entidad.setIdGrupoIterable(datoClase.getIterable());
-        entidad.setIdInstructor(datoClase.getIdInstructor());
-        entidad.setFecha(datoClase.getFecha());
-        entidad.setHoras(datoClase.getHoras());
-        entidad.setMinutos(datoClase.getMinutos());
-        entidad.setObservacion(datoClase.getObservacion());
         entidad.setEliminado(0);
         ClaseEntidad claseInsertada = repoClase.save(entidad);
-        return Clase.fabricarDeEntidad(claseInsertada);
+        return ClaseMapper.toDominio(claseInsertada);
     }
 
     @Override
@@ -61,8 +48,6 @@ public class ClaseGateway implements IClaseGateway {
         ClaseEntidad entidad = repoClase.findById(id).orElseThrow(NoExisteExcepcion::new);
         repoClase.marcarComoEliminado(id);
         entidad.setEliminado(1);
-        return Clase.fabricarDeEntidad(entidad);
-
+        return ClaseMapper.toDominio(entidad);
     }
-
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/ClaseMapper.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/ClaseMapper.java
@@ -1,0 +1,91 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.mappers;
+
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoProcesableEntidadException;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Clase;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.ClaseDto;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.ClaseEntidad;
+
+public class ClaseMapper {
+
+    // ClaseEntidad usa idGrupoCategoria/idGrupoCurso/idGrupoAnio/idGrupoIterable;
+    // Clase y ClaseDto usan categoria/curso/anio/iterable.
+    public static Clase toDominio(ClaseEntidad entidad) {
+        try {
+            Clase modelo = new Clase();
+            modelo.setCodigo(entidad.getCodigo());
+            modelo.setCategoria(entidad.getIdGrupoCategoria());
+            modelo.setCurso(entidad.getIdGrupoCurso());
+            modelo.setAnio(entidad.getIdGrupoAnio());
+            modelo.setIterable(entidad.getIdGrupoIterable());
+            modelo.setIdInstructor(entidad.getIdInstructor());
+            modelo.setFecha(entidad.getFecha());
+            modelo.setHoras(entidad.getHoras());
+            modelo.setMinutos(entidad.getMinutos());
+            modelo.setObservacion(entidad.getObservacion());
+            modelo.setEliminado(entidad.getEliminado());
+            return modelo;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir ClaseEntidad a dominio: " + e.getMessage());
+        }
+    }
+
+    public static ClaseEntidad toEntidad(Clase clase) {
+        try {
+            ClaseEntidad entidad = new ClaseEntidad();
+            entidad.setCodigo(clase.getCodigo());
+            entidad.setIdGrupoCategoria(clase.getCategoria());
+            entidad.setIdGrupoCurso(clase.getCurso());
+            entidad.setIdGrupoAnio(clase.getAnio());
+            entidad.setIdGrupoIterable(clase.getIterable());
+            entidad.setIdInstructor(clase.getIdInstructor());
+            entidad.setFecha(clase.getFecha());
+            entidad.setHoras(clase.getHoras());
+            entidad.setMinutos(clase.getMinutos());
+            entidad.setObservacion(clase.getObservacion());
+            entidad.setEliminado(clase.getEliminado());
+            return entidad;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir Clase a entidad: " + e.getMessage());
+        }
+    }
+
+    public static ClaseDto toDto(Clase clase) {
+        try {
+            ClaseDto dto = new ClaseDto();
+            dto.setCodigo(clase.getCodigo());
+            dto.setCategoria(clase.getCategoria());
+            dto.setCurso(clase.getCurso());
+            dto.setAnio(clase.getAnio());
+            dto.setIterable(clase.getIterable());
+            dto.setIdInstructor(clase.getIdInstructor());
+            dto.setFecha(clase.getFecha());
+            dto.setHoras(clase.getHoras());
+            dto.setMinutos(clase.getMinutos());
+            dto.setObservacion(clase.getObservacion());
+            dto.setEliminado(clase.getEliminado());
+            return dto;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir Clase a DTO: " + e.getMessage());
+        }
+    }
+
+    public static Clase fromDto(ClaseDto dto) {
+        try {
+            Clase modelo = new Clase();
+            modelo.setCodigo(dto.getCodigo());
+            modelo.setCategoria(dto.getCategoria());
+            modelo.setCurso(dto.getCurso());
+            modelo.setAnio(dto.getAnio());
+            modelo.setIterable(dto.getIterable());
+            modelo.setIdInstructor(dto.getIdInstructor());
+            modelo.setFecha(dto.getFecha());
+            modelo.setHoras(dto.getHoras());
+            modelo.setMinutos(dto.getMinutos());
+            modelo.setObservacion(dto.getObservacion());
+            modelo.setEliminado(dto.getEliminado());
+            return modelo;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir ClaseDto a dominio: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/ClaseServicioTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/ClaseServicioTest.java
@@ -1,0 +1,112 @@
+package co.edu.unicauca.deporteParaTodos.dominio.servicios;
+
+import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosSalida.IClaseGateway;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Clase;
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.ListadoVacioExcepcion;
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Date;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClaseServicioTest {
+
+    @Mock
+    private IClaseGateway claseGateway;
+
+    @InjectMocks
+    private ClaseServicio claseServicio;
+
+    private static final String  CATEGORIA = "Recreativo";
+    private static final String  CURSO     = "Natacion";
+    private static final Integer ANIO      = 2025;
+    private static final Integer ITERABLE  = 1;
+
+    private Clase claseBase() {
+        Clase c = new Clase();
+        c.setCodigo(1);
+        c.setCategoria(CATEGORIA);
+        c.setCurso(CURSO);
+        c.setAnio(ANIO);
+        c.setIterable(ITERABLE);
+        c.setIdInstructor("INS001");
+        c.setFecha(Date.valueOf("2025-01-15"));
+        c.setHoras(1);
+        c.setMinutos(30);
+        c.setEliminado(0);
+        return c;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // obtenerClasesGrupo
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void obtenerClasesGrupo_exitoso_retornaListado() {
+        when(claseGateway.obtenerClasesGrupo(CATEGORIA, CURSO, ANIO, ITERABLE))
+                .thenReturn(List.of(claseBase(), claseBase()));
+
+        List<Clase> resultado = claseServicio.obtenerClasesGrupo(CATEGORIA, CURSO, ANIO, ITERABLE);
+
+        assertEquals(2, resultado.size());
+        verify(claseGateway).obtenerClasesGrupo(CATEGORIA, CURSO, ANIO, ITERABLE);
+    }
+
+    @Test
+    void obtenerClasesGrupo_vacio_lanzaListadoVacioExcepcion() {
+        when(claseGateway.obtenerClasesGrupo(CATEGORIA, CURSO, ANIO, ITERABLE))
+                .thenReturn(Collections.emptyList());
+
+        assertThrows(ListadoVacioExcepcion.class,
+                () -> claseServicio.obtenerClasesGrupo(CATEGORIA, CURSO, ANIO, ITERABLE));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // insertarClase
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void insertarClase_exitoso_delegaAlGateway() {
+        when(claseGateway.insertarClase(any(Clase.class))).thenReturn(claseBase());
+
+        Clase resultado = claseServicio.insertarClase(claseBase());
+
+        assertNotNull(resultado);
+        assertEquals(CATEGORIA, resultado.getCategoria());
+        verify(claseGateway).insertarClase(any(Clase.class));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // eliminarClase
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void eliminarClase_exitoso_delegaAlGateway() {
+        when(claseGateway.existeClase(1)).thenReturn(true);
+        when(claseGateway.eliminarClase(1)).thenReturn(claseBase());
+
+        Clase resultado = claseServicio.eliminarClase(1);
+
+        assertNotNull(resultado);
+        verify(claseGateway).eliminarClase(1);
+    }
+
+    @Test
+    void eliminarClase_noExiste_lanzaNoExisteExcepcion() {
+        when(claseGateway.existeClase(99)).thenReturn(false);
+
+        assertThrows(NoExisteExcepcion.class, () -> claseServicio.eliminarClase(99));
+
+        verify(claseGateway, never()).eliminarClase(anyInt());
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/ClaseRestTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/ClaseRestTest.java
@@ -1,0 +1,109 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.api;
+
+import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.IClaseServicio;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Clase;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.ClaseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.sql.Date;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClaseRestTest {
+
+    @Mock
+    private IClaseServicio servicioClase;
+
+    @InjectMocks
+    private ClaseRest claseRest;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(claseRest)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+    }
+
+    private Clase claseBase() {
+        Clase c = new Clase();
+        c.setCodigo(1);
+        c.setCategoria("Recreativo");
+        c.setCurso("Natacion");
+        c.setAnio(2025);
+        c.setIterable(1);
+        c.setIdInstructor("INS001");
+        c.setFecha(Date.valueOf("2025-01-15"));
+        c.setHoras(1);
+        c.setMinutos(30);
+        c.setEliminado(0);
+        return c;
+    }
+
+    @Test
+    void getClasesGrupo_retornaListaDto() throws Exception {
+        when(servicioClase.obtenerClasesGrupo(anyString(), anyString(), anyInt(), anyInt()))
+                .thenReturn(List.of(claseBase()));
+
+        // ClaseDto serializa categoria como "idGrupoCategoria" por @JsonProperty
+        mockMvc.perform(get("/api/v2/clasesGrupo")
+                        .param("categoria", "Recreativo")
+                        .param("curso", "Natacion")
+                        .param("anio", "2025")
+                        .param("iterable", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].idGrupoCategoria").value("Recreativo"))
+                .andExpect(jsonPath("$[0].idGrupoCurso").value("Natacion"))
+                .andExpect(jsonPath("$[0].codigo").value(1));
+    }
+
+    @Test
+    void postClase_retornaCreated() throws Exception {
+        when(servicioClase.insertarClase(any(Clase.class))).thenReturn(claseBase());
+
+        ClaseDto dto = new ClaseDto();
+        dto.setCategoria("Recreativo");
+        dto.setCurso("Natacion");
+        dto.setAnio(2025);
+        dto.setIterable(1);
+        dto.setIdInstructor("INS001");
+        dto.setFecha(Date.valueOf("2025-01-15"));
+        dto.setHoras(1);
+        dto.setMinutos(30);
+
+        mockMvc.perform(post("/api/v2/claseGrupo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.idGrupoCategoria").value("Recreativo"))
+                .andExpect(jsonPath("$.codigo").value(1));
+    }
+
+    @Test
+    void deleteClase_retornaOk() throws Exception {
+        when(servicioClase.eliminarClase(anyInt())).thenReturn(claseBase());
+
+        mockMvc.perform(delete("/api/v2/clase")
+                        .param("id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.codigo").value(1))
+                .andExpect(jsonPath("$.eliminado").value(0));
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/ClaseGatewayTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/ClaseGatewayTest.java
@@ -1,0 +1,110 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.gateway;
+
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Clase;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.ClaseEntidad;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.repositorios.IClaseRepositorio;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClaseGatewayTest {
+
+    @Mock
+    private IClaseRepositorio repoClase;
+
+    @InjectMocks
+    private ClaseGateway claseGateway;
+
+    private static final String  CATEGORIA = "Recreativo";
+    private static final String  CURSO     = "Natacion";
+    private static final Integer ANIO      = 2025;
+    private static final Integer ITERABLE  = 1;
+    private static final Date    FECHA     = Date.valueOf("2025-01-15");
+
+    private ClaseEntidad entidadBase() {
+        ClaseEntidad e = new ClaseEntidad();
+        e.setCodigo(1);
+        e.setIdGrupoCategoria(CATEGORIA);
+        e.setIdGrupoCurso(CURSO);
+        e.setIdGrupoAnio(ANIO);
+        e.setIdGrupoIterable(ITERABLE);
+        e.setIdInstructor("INS001");
+        e.setFecha(FECHA);
+        e.setHoras(1);
+        e.setMinutos(30);
+        e.setEliminado(0);
+        return e;
+    }
+
+    private Clase claseBase() {
+        Clase c = new Clase();
+        c.setCodigo(1);
+        c.setCategoria(CATEGORIA);
+        c.setCurso(CURSO);
+        c.setAnio(ANIO);
+        c.setIterable(ITERABLE);
+        c.setIdInstructor("INS001");
+        c.setFecha(FECHA);
+        c.setHoras(1);
+        c.setMinutos(30);
+        c.setEliminado(0);
+        return c;
+    }
+
+    @Test
+    void insertarClase_guardaEntidadConCodigoNuloYEliminado0() {
+        when(repoClase.save(any(ClaseEntidad.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        claseGateway.insertarClase(claseBase());
+
+        ArgumentCaptor<ClaseEntidad> captor = ArgumentCaptor.forClass(ClaseEntidad.class);
+        verify(repoClase).save(captor.capture());
+        assertNull(captor.getValue().getCodigo());
+        assertEquals(0,         captor.getValue().getEliminado());
+        assertEquals(CATEGORIA, captor.getValue().getIdGrupoCategoria());
+        assertEquals(CURSO,     captor.getValue().getIdGrupoCurso());
+    }
+
+    @Test
+    void obtenerClasesGrupo_retornaListaMapeadaDesdeEntidades() {
+        when(repoClase.findByIdGrupoCategoriaAndIdGrupoCursoAndIdGrupoAnioAndIdGrupoIterableAndEliminado(
+                anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+                .thenReturn(List.of(entidadBase()));
+
+        List<Clase> resultado = claseGateway.obtenerClasesGrupo(CATEGORIA, CURSO, ANIO, ITERABLE);
+
+        assertEquals(1,         resultado.size());
+        assertEquals(CATEGORIA, resultado.get(0).getCategoria());
+        assertEquals(CURSO,     resultado.get(0).getCurso());
+    }
+
+    @Test
+    void eliminarClase_existente_llamamarcarComoEliminadoYRetornaEliminado1() {
+        when(repoClase.findById(1)).thenReturn(Optional.of(entidadBase()));
+
+        Clase resultado = claseGateway.eliminarClase(1);
+
+        verify(repoClase).marcarComoEliminado(1);
+        assertEquals(1, resultado.getEliminado());
+    }
+
+    @Test
+    void eliminarClase_noExiste_lanzaNoExisteExcepcion() {
+        when(repoClase.findById(99)).thenReturn(Optional.empty());
+
+        assertThrows(NoExisteExcepcion.class, () -> claseGateway.eliminarClase(99));
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/ClaseMapperTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/ClaseMapperTest.java
@@ -1,0 +1,170 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.mappers;
+
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoProcesableEntidadException;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Clase;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.ClaseDto;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.ClaseEntidad;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClaseMapperTest {
+
+    private static final String CATEGORIA  = "Recreativo";
+    private static final String CURSO      = "Natacion";
+    private static final Integer ANIO      = 2025;
+    private static final Integer ITERABLE  = 1;
+    private static final Date    FECHA     = Date.valueOf("2025-01-15");
+
+    private ClaseEntidad entidadBase() {
+        ClaseEntidad e = new ClaseEntidad();
+        e.setCodigo(10);
+        e.setIdGrupoCategoria(CATEGORIA);
+        e.setIdGrupoCurso(CURSO);
+        e.setIdGrupoAnio(ANIO);
+        e.setIdGrupoIterable(ITERABLE);
+        e.setIdInstructor("INS001");
+        e.setFecha(FECHA);
+        e.setHoras(1);
+        e.setMinutos(30);
+        e.setObservacion("obs");
+        e.setEliminado(0);
+        return e;
+    }
+
+    private Clase claseBase() {
+        Clase c = new Clase();
+        c.setCodigo(10);
+        c.setCategoria(CATEGORIA);
+        c.setCurso(CURSO);
+        c.setAnio(ANIO);
+        c.setIterable(ITERABLE);
+        c.setIdInstructor("INS001");
+        c.setFecha(FECHA);
+        c.setHoras(1);
+        c.setMinutos(30);
+        c.setObservacion("obs");
+        c.setEliminado(0);
+        return c;
+    }
+
+    // ────────── toDominio ──────────
+
+    @Test
+    void toDominio_renombraCamposDeEntidadADominio() {
+        // idGrupoCategoria → categoria, idGrupoCurso → curso, idGrupoAnio → anio, idGrupoIterable → iterable
+        Clase resultado = ClaseMapper.toDominio(entidadBase());
+        assertEquals(CATEGORIA, resultado.getCategoria());
+        assertEquals(CURSO,     resultado.getCurso());
+        assertEquals(ANIO,      resultado.getAnio());
+        assertEquals(ITERABLE,  resultado.getIterable());
+    }
+
+    @Test
+    void toDominio_preservaCamposDirectos() {
+        Clase resultado = ClaseMapper.toDominio(entidadBase());
+        assertEquals(10,       resultado.getCodigo());
+        assertEquals("INS001", resultado.getIdInstructor());
+        assertEquals(FECHA,    resultado.getFecha());
+        assertEquals(1,        resultado.getHoras());
+        assertEquals(30,       resultado.getMinutos());
+        assertEquals(0,        resultado.getEliminado());
+    }
+
+    @Test
+    void toDominio_entidadNula_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> ClaseMapper.toDominio(null));
+    }
+
+    // ────────── toEntidad ──────────
+
+    @Test
+    void toEntidad_renombraCamposDeDominioAEntidad() {
+        // categoria → idGrupoCategoria, curso → idGrupoCurso, anio → idGrupoAnio, iterable → idGrupoIterable
+        ClaseEntidad resultado = ClaseMapper.toEntidad(claseBase());
+        assertEquals(CATEGORIA, resultado.getIdGrupoCategoria());
+        assertEquals(CURSO,     resultado.getIdGrupoCurso());
+        assertEquals(ANIO,      resultado.getIdGrupoAnio());
+        assertEquals(ITERABLE,  resultado.getIdGrupoIterable());
+    }
+
+    @Test
+    void toEntidad_preservaCamposDirectos() {
+        ClaseEntidad resultado = ClaseMapper.toEntidad(claseBase());
+        assertEquals(10,       resultado.getCodigo());
+        assertEquals("INS001", resultado.getIdInstructor());
+        assertEquals(FECHA,    resultado.getFecha());
+        assertEquals(1,        resultado.getHoras());
+        assertEquals(30,       resultado.getMinutos());
+    }
+
+    @Test
+    void toEntidad_claseNula_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> ClaseMapper.toEntidad(null));
+    }
+
+    // ────────── toDto ──────────
+
+    @Test
+    void toDto_claseValida_mapeaCamposCorrectamente() {
+        ClaseDto resultado = ClaseMapper.toDto(claseBase());
+        assertEquals(CATEGORIA, resultado.getCategoria());
+        assertEquals(CURSO,     resultado.getCurso());
+        assertEquals(ANIO,      resultado.getAnio());
+        assertEquals(ITERABLE,  resultado.getIterable());
+        assertEquals(10,        resultado.getCodigo());
+        assertEquals(FECHA,     resultado.getFecha());
+    }
+
+    @Test
+    void toDto_claseNula_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> ClaseMapper.toDto(null));
+    }
+
+    // ────────── fromDto ──────────
+
+    @Test
+    void fromDto_dtoValido_mapeaCamposCorrectamente() {
+        ClaseDto dto = new ClaseDto();
+        dto.setCodigo(10);
+        dto.setCategoria(CATEGORIA);
+        dto.setCurso(CURSO);
+        dto.setAnio(ANIO);
+        dto.setIterable(ITERABLE);
+        dto.setIdInstructor("INS001");
+        dto.setFecha(FECHA);
+        dto.setHoras(1);
+        dto.setMinutos(30);
+
+        Clase resultado = ClaseMapper.fromDto(dto);
+
+        assertEquals(CATEGORIA, resultado.getCategoria());
+        assertEquals(CURSO,     resultado.getCurso());
+        assertEquals(ANIO,      resultado.getAnio());
+        assertEquals(10,        resultado.getCodigo());
+        assertEquals(FECHA,     resultado.getFecha());
+    }
+
+    @Test
+    void fromDto_preservaObservacionYEliminado() {
+        ClaseDto dto = new ClaseDto();
+        dto.setCategoria(CATEGORIA);
+        dto.setCurso(CURSO);
+        dto.setAnio(ANIO);
+        dto.setIterable(ITERABLE);
+        dto.setObservacion("nota extra");
+        dto.setEliminado(0);
+
+        Clase resultado = ClaseMapper.fromDto(dto);
+
+        assertEquals("nota extra", resultado.getObservacion());
+        assertEquals(0,            resultado.getEliminado());
+    }
+
+    @Test
+    void fromDto_dtoNulo_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> ClaseMapper.fromDto(null));
+    }
+}


### PR DESCRIPTION
Sexto modulo del refactor de arquitectura (H-01/H-02/H-05), 
replicando el patron validado en Curso, Categoria, Escenario, 
Horario y Grupo. Clase.java (dominio) ya no importa ClaseDto ni 
ClaseEntidad -- se crea ClaseMapper centralizando las 4 conversiones, 
con manejo cuidadoso de la asimetria de nombres entre ClaseEntidad 
(idGrupoCategoria, idGrupoCurso, idGrupoAnio, idGrupoIterable) y 
Clase (categoria, curso, anio, iterable), validada campo por campo.

Modulo sin tests previos -- 23 tests nuevos (11 mapper + 5 servicio 
+ 4 gateway + 3 controller), todo New Code. Cobertura proyectada 
89%, por encima del 80% requerido.

251/251 tests, BUILD SUCCESS.