### PR TITLE
Inscripcion ya no depende de código de base de datos ni de la API REST

### DIFF
--- a/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/modelo/Inscripcion.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/modelo/Inscripcion.java
@@ -2,8 +2,6 @@ package co.edu.unicauca.deporteParaTodos.dominio.modelo;
 
 import java.sql.Timestamp;
 
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.InscripcionDto;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.InscripcionEntidad;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,36 +20,4 @@ public class Inscripcion {
     private int iterable;
     private Timestamp fechaInscripcion;
     private Timestamp fechaDesvinculacion;
-
-    public static Inscripcion fabricarDeEntidad(InscripcionEntidad entidad) {
-        try {
-            Inscripcion inscripcion = new Inscripcion();
-            inscripcion.setAlumnoId(entidad.getAlumnoId());
-            inscripcion.setCategoria(entidad.getCategoria());
-            inscripcion.setCurso(entidad.getCurso());
-            inscripcion.setAnio(entidad.getAnio());
-            inscripcion.setIterable(entidad.getIterable());
-            inscripcion.setFechaInscripcion(entidad.getFechaInscripcion());
-            inscripcion.setFechaDesvinculacion(entidad.getFechaDesvinculacion());
-            return inscripcion;
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    public static Inscripcion fabricarDeDto(InscripcionDto dto) {
-        try {
-            Inscripcion inscripcion = new Inscripcion();
-            inscripcion.setAlumnoId(dto.getAlumnoId());
-            inscripcion.setCategoria(dto.getCategoria());
-            inscripcion.setCurso(dto.getCurso());
-            inscripcion.setAnio(dto.getAnio());
-            inscripcion.setIterable(dto.getIterable());
-            inscripcion.setFechaInscripcion(dto.getFechaInscripcion());
-            inscripcion.setFechaDesvinculacion(dto.getFechaDesvinculacion());
-            return inscripcion;
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/DTOs/InscripcionDto.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/DTOs/InscripcionDto.java
@@ -2,7 +2,6 @@ package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadores
 
 import java.sql.Timestamp;
 
-import co.edu.unicauca.deporteParaTodos.dominio.modelo.Inscripcion;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,20 +20,4 @@ public class InscripcionDto {
     private int iterable;
     private Timestamp fechaInscripcion;
     private Timestamp fechaDesvinculacion;
-
-    public static InscripcionDto fabricarDeModelo(Inscripcion inscripcion) {
-        try {
-            InscripcionDto dto = new InscripcionDto();
-            dto.setAlumnoId(inscripcion.getAlumnoId());
-            dto.setCategoria(inscripcion.getCategoria());
-            dto.setCurso(inscripcion.getCurso());
-            dto.setAnio(inscripcion.getAnio());
-            dto.setIterable(inscripcion.getIterable());
-            dto.setFechaInscripcion(inscripcion.getFechaInscripcion());
-            dto.setFechaDesvinculacion(inscripcion.getFechaDesvinculacion());
-            return dto;
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/InscripcionRest.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/InscripcionRest.java
@@ -13,6 +13,7 @@ import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.IInscr
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Inscripcion;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.InscripcionDto;
 import co.edu.unicauca.deporteParaTodos.infraestructura.logs.PeticionLogger;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.InscripcionMapper;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,9 +34,9 @@ public class InscripcionRest {
     @PostMapping("/inscripcion")
     public ResponseEntity<InscripcionDto> inscribir(@RequestBody InscripcionDto dto) {
         PeticionLogger.log(LOGGER, "POST", "/api/v2/inscripcion", dto);
-        Inscripcion inscripcion = Inscripcion.fabricarDeDto(dto);
+        Inscripcion inscripcion = InscripcionMapper.fromDto(dto);
         Inscripcion resultado = servicio.inscribir(inscripcion);
-        return new ResponseEntity<>(InscripcionDto.fabricarDeModelo(resultado), HttpStatus.CREATED);
+        return new ResponseEntity<>(InscripcionMapper.toDto(resultado), HttpStatus.CREATED);
     }
 
     @GetMapping("/validarInscripcion")
@@ -55,6 +56,6 @@ public class InscripcionRest {
         PeticionLogger.log(LOGGER, "PUT", "/api/v2/desvincularInscripcion", dto);
         Inscripcion resultado = servicio.desvincularInscripcion(
                 dto.getAlumnoId(), dto.getCategoria(), dto.getCurso(), dto.getAnio(), dto.getIterable());
-        return new ResponseEntity<>(InscripcionDto.fabricarDeModelo(resultado), HttpStatus.OK);
+        return new ResponseEntity<>(InscripcionMapper.toDto(resultado), HttpStatus.OK);
     }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/entidades/InscripcionEntidad.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/entidades/InscripcionEntidad.java
@@ -2,8 +2,6 @@ package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadores
 
 import java.sql.Timestamp;
 
-import co.edu.unicauca.deporteParaTodos.dominio.modelo.Inscripcion;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.ids.GrupoId;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.ids.InscripcionId;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -57,21 +55,4 @@ public class InscripcionEntidad {
 
     @Column(name = "META_ELIMINADO")
     private int eliminado;
-
-    public static InscripcionEntidad fabricarDeModelo(Inscripcion inscripcion) {
-        try {
-            InscripcionEntidad entidad = new InscripcionEntidad();
-            entidad.setAlumnoId(inscripcion.getAlumnoId());
-            entidad.setCategoria(inscripcion.getCategoria());
-            entidad.setCurso(inscripcion.getCurso());
-            entidad.setAnio(inscripcion.getAnio());
-            entidad.setIterable(inscripcion.getIterable());
-            entidad.setFechaInscripcion(inscripcion.getFechaInscripcion());
-            entidad.setFechaDesvinculacion(inscripcion.getFechaDesvinculacion());
-            entidad.setEliminado(0);
-            return entidad;
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/InscripcionGateway.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/InscripcionGateway.java
@@ -8,11 +8,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosSalida.IInscripcionGateway;
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Inscripcion;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.InscripcionEntidad;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.ids.InscripcionId;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.repositorios.IInscripcionRepositorio;
-import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.InscripcionMapper;
 
 @Service
 public class InscripcionGateway implements IInscripcionGateway {
@@ -38,14 +39,14 @@ public class InscripcionGateway implements IInscripcionGateway {
         if (op.isEmpty()) {
             throw new NoExisteExcepcion("La inscripcion buscada no existe");
         }
-        return Inscripcion.fabricarDeEntidad(op.get());
+        return InscripcionMapper.toDominio(op.get());
     }
 
     @Override
     public Inscripcion guardarInscripcion(Inscripcion inscripcion) {
-        InscripcionEntidad entidad = InscripcionEntidad.fabricarDeModelo(inscripcion);
+        InscripcionEntidad entidad = InscripcionMapper.toEntidad(inscripcion);
         InscripcionEntidad guardada = repoInscrp.save(entidad);
-        return Inscripcion.fabricarDeEntidad(guardada);
+        return InscripcionMapper.toDominio(guardada);
     }
 
     @Override
@@ -58,6 +59,6 @@ public class InscripcionGateway implements IInscripcionGateway {
         InscripcionEntidad entidad = op.get();
         entidad.setFechaDesvinculacion(Timestamp.from(Instant.now()));
         InscripcionEntidad guardada = repoInscrp.save(entidad);
-        return Inscripcion.fabricarDeEntidad(guardada);
+        return InscripcionMapper.toDominio(guardada);
     }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/InscripcionMapper.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/InscripcionMapper.java
@@ -1,0 +1,74 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.mappers;
+
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoProcesableEntidadException;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Inscripcion;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.InscripcionDto;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.InscripcionEntidad;
+
+public class InscripcionMapper {
+
+    public static Inscripcion toDominio(InscripcionEntidad entidad) {
+        try {
+            Inscripcion modelo = new Inscripcion();
+            modelo.setAlumnoId(entidad.getAlumnoId());
+            modelo.setCategoria(entidad.getCategoria());
+            modelo.setCurso(entidad.getCurso());
+            modelo.setAnio(entidad.getAnio());
+            modelo.setIterable(entidad.getIterable());
+            modelo.setFechaInscripcion(entidad.getFechaInscripcion());
+            modelo.setFechaDesvinculacion(entidad.getFechaDesvinculacion());
+            return modelo;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir InscripcionEntidad a dominio: " + e.getMessage());
+        }
+    }
+
+    public static InscripcionEntidad toEntidad(Inscripcion inscripcion) {
+        try {
+            InscripcionEntidad entidad = new InscripcionEntidad();
+            entidad.setAlumnoId(inscripcion.getAlumnoId());
+            entidad.setCategoria(inscripcion.getCategoria());
+            entidad.setCurso(inscripcion.getCurso());
+            entidad.setAnio(inscripcion.getAnio());
+            entidad.setIterable(inscripcion.getIterable());
+            entidad.setFechaInscripcion(inscripcion.getFechaInscripcion());
+            entidad.setFechaDesvinculacion(inscripcion.getFechaDesvinculacion());
+            entidad.setEliminado(0);
+            return entidad;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir Inscripcion a entidad: " + e.getMessage());
+        }
+    }
+
+    public static InscripcionDto toDto(Inscripcion inscripcion) {
+        try {
+            InscripcionDto dto = new InscripcionDto();
+            dto.setAlumnoId(inscripcion.getAlumnoId());
+            dto.setCategoria(inscripcion.getCategoria());
+            dto.setCurso(inscripcion.getCurso());
+            dto.setAnio(inscripcion.getAnio());
+            dto.setIterable(inscripcion.getIterable());
+            dto.setFechaInscripcion(inscripcion.getFechaInscripcion());
+            dto.setFechaDesvinculacion(inscripcion.getFechaDesvinculacion());
+            return dto;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir Inscripcion a DTO: " + e.getMessage());
+        }
+    }
+
+    public static Inscripcion fromDto(InscripcionDto dto) {
+        try {
+            Inscripcion modelo = new Inscripcion();
+            modelo.setAlumnoId(dto.getAlumnoId());
+            modelo.setCategoria(dto.getCategoria());
+            modelo.setCurso(dto.getCurso());
+            modelo.setAnio(dto.getAnio());
+            modelo.setIterable(dto.getIterable());
+            modelo.setFechaInscripcion(dto.getFechaInscripcion());
+            modelo.setFechaDesvinculacion(dto.getFechaDesvinculacion());
+            return modelo;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir InscripcionDto a dominio: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/InscripcionRestTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/InscripcionRestTest.java
@@ -1,0 +1,116 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.api;
+
+import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.IInscripcionServicio;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Inscripcion;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.InscripcionDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class InscripcionRestTest {
+
+    @Mock
+    private IInscripcionServicio servicio;
+
+    @InjectMocks
+    private InscripcionRest inscripcionRest;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final String    ALUMNO_ID = "alum1";
+    private static final String    CATEGORIA = "cat1";
+    private static final String    CURSO     = "cur1";
+    private static final int       ANIO      = 2026;
+    private static final int       ITERABLE  = 1;
+    private static final Timestamp AHORA     = Timestamp.from(Instant.now());
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(inscripcionRest)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+    }
+
+    private Inscripcion inscripcionBase() {
+        return new Inscripcion(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE, AHORA, null);
+    }
+
+    @Test
+    void postInscribir_retornaCreated() throws Exception {
+        when(servicio.inscribir(any(Inscripcion.class))).thenReturn(inscripcionBase());
+
+        InscripcionDto dto = new InscripcionDto(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE, null, null);
+
+        mockMvc.perform(post("/api/v2/inscripcion")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.alumnoId").value(ALUMNO_ID))
+                .andExpect(jsonPath("$.categoria").value(CATEGORIA))
+                .andExpect(jsonPath("$.curso").value(CURSO));
+    }
+
+    @Test
+    void getValidarInscripcion_activa_retornaTrue() throws Exception {
+        when(servicio.validarInscripcion(anyString(), anyString(), anyString(), anyInt(), anyInt()))
+                .thenReturn(true);
+
+        mockMvc.perform(get("/api/v2/validarInscripcion")
+                        .param("alumnoId", ALUMNO_ID)
+                        .param("categoria", CATEGORIA)
+                        .param("curso", CURSO)
+                        .param("anio", String.valueOf(ANIO))
+                        .param("iterable", String.valueOf(ITERABLE)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"));
+    }
+
+    @Test
+    void getValidarInscripcion_inactiva_retornaFalse() throws Exception {
+        when(servicio.validarInscripcion(anyString(), anyString(), anyString(), anyInt(), anyInt()))
+                .thenReturn(false);
+
+        mockMvc.perform(get("/api/v2/validarInscripcion")
+                        .param("alumnoId", ALUMNO_ID)
+                        .param("categoria", CATEGORIA)
+                        .param("curso", CURSO)
+                        .param("anio", String.valueOf(ANIO))
+                        .param("iterable", String.valueOf(ITERABLE)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("false"));
+    }
+
+    @Test
+    void putDesvincularInscripcion_retornaOk() throws Exception {
+        Inscripcion desvinculada = new Inscripcion(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE, AHORA, AHORA);
+        when(servicio.desvincularInscripcion(anyString(), anyString(), anyString(), anyInt(), anyInt()))
+                .thenReturn(desvinculada);
+
+        InscripcionDto dto = new InscripcionDto(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE, null, null);
+
+        mockMvc.perform(put("/api/v2/desvincularInscripcion")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.alumnoId").value(ALUMNO_ID))
+                .andExpect(jsonPath("$.categoria").value(CATEGORIA));
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/InscripcionGatewayTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/InscripcionGatewayTest.java
@@ -1,0 +1,115 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.gateway;
+
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Inscripcion;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.InscripcionEntidad;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.repositorios.IInscripcionRepositorio;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InscripcionGatewayTest {
+
+    @Mock
+    private IInscripcionRepositorio repoInscrp;
+
+    @InjectMocks
+    private InscripcionGateway gateway;
+
+    private static final String    ALUMNO_ID = "alum1";
+    private static final String    CATEGORIA = "cat1";
+    private static final String    CURSO     = "cur1";
+    private static final int       ANIO      = 2026;
+    private static final int       ITERABLE  = 1;
+    private static final Timestamp AHORA     = Timestamp.from(Instant.now());
+
+    private InscripcionEntidad entidadBase() {
+        InscripcionEntidad e = new InscripcionEntidad();
+        e.setAlumnoId(ALUMNO_ID);
+        e.setCategoria(CATEGORIA);
+        e.setCurso(CURSO);
+        e.setAnio(ANIO);
+        e.setIterable(ITERABLE);
+        e.setFechaInscripcion(AHORA);
+        e.setFechaDesvinculacion(null);
+        e.setEliminado(0);
+        return e;
+    }
+
+    @Test
+    void existeInscripcion_returnTrue() {
+        when(repoInscrp.existsById(any())).thenReturn(true);
+        assertTrue(gateway.existeInscripcion(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE));
+    }
+
+    @Test
+    void existeInscripcionActiva_returnTrue() {
+        when(repoInscrp.existeInscripcionActiva(anyString(), anyString(), anyString(), anyInt(), anyInt()))
+                .thenReturn(true);
+        assertTrue(gateway.existeInscripcionActiva(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE));
+    }
+
+    @Test
+    void obtenerInscripcion_existente_retornaInscripcion() {
+        when(repoInscrp.findById(any())).thenReturn(Optional.of(entidadBase()));
+
+        Inscripcion resultado = gateway.obtenerInscripcion(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE);
+
+        assertNotNull(resultado);
+        assertEquals(ALUMNO_ID, resultado.getAlumnoId());
+        assertEquals(CATEGORIA, resultado.getCategoria());
+    }
+
+    @Test
+    void obtenerInscripcion_noExiste_lanzaNoExisteExcepcion() {
+        when(repoInscrp.findById(any())).thenReturn(Optional.empty());
+
+        assertThrows(NoExisteExcepcion.class,
+                () -> gateway.obtenerInscripcion(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE));
+    }
+
+    @Test
+    void guardarInscripcion_retornaInscripcionGuardada() {
+        when(repoInscrp.save(any(InscripcionEntidad.class))).thenReturn(entidadBase());
+
+        Inscripcion input = new Inscripcion(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE, AHORA, null);
+        Inscripcion resultado = gateway.guardarInscripcion(input);
+
+        assertNotNull(resultado);
+        assertEquals(ALUMNO_ID, resultado.getAlumnoId());
+        assertEquals(CATEGORIA, resultado.getCategoria());
+        verify(repoInscrp).save(any(InscripcionEntidad.class));
+    }
+
+    @Test
+    void desvincularInscripcion_existente_setFechaDesvinculacionYGuarda() {
+        when(repoInscrp.findById(any())).thenReturn(Optional.of(entidadBase()));
+        when(repoInscrp.save(any(InscripcionEntidad.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Inscripcion resultado = gateway.desvincularInscripcion(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE);
+
+        assertNotNull(resultado);
+        assertNotNull(resultado.getFechaDesvinculacion());
+        verify(repoInscrp).save(any(InscripcionEntidad.class));
+    }
+
+    @Test
+    void desvincularInscripcion_noExiste_lanzaNoExisteExcepcion() {
+        when(repoInscrp.findById(any())).thenReturn(Optional.empty());
+
+        assertThrows(NoExisteExcepcion.class,
+                () -> gateway.desvincularInscripcion(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE));
+        verify(repoInscrp, never()).save(any());
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/InscripcionMapperTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/InscripcionMapperTest.java
@@ -1,0 +1,141 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.mappers;
+
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoProcesableEntidadException;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Inscripcion;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.InscripcionDto;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.InscripcionEntidad;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InscripcionMapperTest {
+
+    private static final String ALUMNO_ID  = "alum1";
+    private static final String CATEGORIA  = "cat1";
+    private static final String CURSO      = "cur1";
+    private static final int    ANIO       = 2026;
+    private static final int    ITERABLE   = 1;
+    private static final Timestamp AHORA   = Timestamp.from(Instant.now());
+
+    private InscripcionEntidad entidadBase() {
+        InscripcionEntidad e = new InscripcionEntidad();
+        e.setAlumnoId(ALUMNO_ID);
+        e.setCategoria(CATEGORIA);
+        e.setCurso(CURSO);
+        e.setAnio(ANIO);
+        e.setIterable(ITERABLE);
+        e.setFechaInscripcion(AHORA);
+        e.setFechaDesvinculacion(null);
+        e.setEliminado(0);
+        return e;
+    }
+
+    private Inscripcion inscripcionBase() {
+        return new Inscripcion(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE, AHORA, null);
+    }
+
+    // ────────── toDominio ──────────
+
+    @Test
+    void toDominio_entidadNula_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> InscripcionMapper.toDominio(null));
+    }
+
+    @Test
+    void toDominio_mapeaTodosLosCamposDeDominio() {
+        Inscripcion resultado = InscripcionMapper.toDominio(entidadBase());
+        assertEquals(ALUMNO_ID, resultado.getAlumnoId());
+        assertEquals(CATEGORIA, resultado.getCategoria());
+        assertEquals(CURSO,     resultado.getCurso());
+        assertEquals(ANIO,      resultado.getAnio());
+        assertEquals(ITERABLE,  resultado.getIterable());
+        assertEquals(AHORA,     resultado.getFechaInscripcion());
+    }
+
+    @Test
+    void toDominio_conFechaDesvinculacionNula_retornaFechaDesvinculacionNula() {
+        InscripcionEntidad entidad = entidadBase();
+        entidad.setFechaDesvinculacion(null);
+        assertNull(InscripcionMapper.toDominio(entidad).getFechaDesvinculacion());
+    }
+
+    // ────────── toEntidad ──────────
+
+    @Test
+    void toEntidad_inscripcionNula_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> InscripcionMapper.toEntidad(null));
+    }
+
+    @Test
+    void toEntidad_mapeaTodosLosCampos() {
+        InscripcionEntidad resultado = InscripcionMapper.toEntidad(inscripcionBase());
+        assertEquals(ALUMNO_ID, resultado.getAlumnoId());
+        assertEquals(CATEGORIA, resultado.getCategoria());
+        assertEquals(CURSO,     resultado.getCurso());
+        assertEquals(ANIO,      resultado.getAnio());
+        assertEquals(ITERABLE,  resultado.getIterable());
+        assertEquals(AHORA,     resultado.getFechaInscripcion());
+    }
+
+    @Test
+    void toEntidad_hardcodeoEliminadoCero() {
+        InscripcionEntidad resultado = InscripcionMapper.toEntidad(inscripcionBase());
+        assertEquals(0, resultado.getEliminado());
+    }
+
+    // ────────── toDto ──────────
+
+    @Test
+    void toDto_inscripcionNula_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> InscripcionMapper.toDto(null));
+    }
+
+    @Test
+    void toDto_mapeaTodosLosCampos() {
+        InscripcionDto resultado = InscripcionMapper.toDto(inscripcionBase());
+        assertEquals(ALUMNO_ID, resultado.getAlumnoId());
+        assertEquals(CATEGORIA, resultado.getCategoria());
+        assertEquals(CURSO,     resultado.getCurso());
+        assertEquals(ANIO,      resultado.getAnio());
+        assertEquals(ITERABLE,  resultado.getIterable());
+        assertEquals(AHORA,     resultado.getFechaInscripcion());
+    }
+
+    @Test
+    void toDto_conFechasNulas_retornaFechasNulas() {
+        Inscripcion inscripcion = new Inscripcion(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE, null, null);
+        InscripcionDto resultado = InscripcionMapper.toDto(inscripcion);
+        assertNull(resultado.getFechaInscripcion());
+        assertNull(resultado.getFechaDesvinculacion());
+    }
+
+    // ────────── fromDto ──────────
+
+    @Test
+    void fromDto_dtoNulo_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> InscripcionMapper.fromDto(null));
+    }
+
+    @Test
+    void fromDto_mapeaTodosLosCampos() {
+        InscripcionDto dto = new InscripcionDto(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE, AHORA, null);
+        Inscripcion resultado = InscripcionMapper.fromDto(dto);
+        assertEquals(ALUMNO_ID, resultado.getAlumnoId());
+        assertEquals(CATEGORIA, resultado.getCategoria());
+        assertEquals(CURSO,     resultado.getCurso());
+        assertEquals(ANIO,      resultado.getAnio());
+        assertEquals(ITERABLE,  resultado.getIterable());
+        assertEquals(AHORA,     resultado.getFechaInscripcion());
+    }
+
+    @Test
+    void fromDto_conFechasNulas_retornaFechasNulas() {
+        InscripcionDto dto = new InscripcionDto(ALUMNO_ID, CATEGORIA, CURSO, ANIO, ITERABLE, null, null);
+        Inscripcion resultado = InscripcionMapper.fromDto(dto);
+        assertNull(resultado.getFechaInscripcion());
+        assertNull(resultado.getFechaDesvinculacion());
+    }
+}


### PR DESCRIPTION
Septimo modulo del refactor de arquitectura (H-01/H-02/H-05), 
replicando el patron validado en Curso, Categoria, Escenario, 
Horario, Grupo e Clase. Inscripcion.java (dominio) ya no importa 
InscripcionDto ni InscripcionEntidad -- se crea InscripcionMapper 
centralizando las 4 conversiones. IInscripcionServicio e 
InscripcionServicio ya cumplian con arquitectura hexagonal (sin 
cambios necesarios).

Eliminado ademas un import muerto (GrupoId) en InscripcionEntidad, 
sin uso real en la clase.

23 tests nuevos (12 mapper + 7 gateway + 4 controller). 274 tests 
totales, BUILD SUCCESS. Cobertura de New Code: 99%, muy por encima 
del 80% requerido.