### PR TITLE
endpoints autenticados rechazaban el token propio del sistema (401)

### DIFF
--- a/src/main/java/co/edu/unicauca/deporteParaTodos/configurations/SecurityConfig.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/configurations/SecurityConfig.java
@@ -8,11 +8,13 @@ import com.nimbusds.jose.proc.SecurityContext;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
@@ -37,10 +39,29 @@ public class SecurityConfig {
     @Value("${app.jwt.secret}")
     private String jwtSecret;
 
+    // Chain 1 (Orden 1): solo /auth/token — recibe Google ID Token y lo decodifica manualmente
+    // en el controller. BearerTokenAuthenticationFilter NO debe interceptar esta ruta porque
+    // el token de Google no puede validarse con el decoder HS256 del sistema.
+    @Bean
+    @Order(1)
+    public SecurityFilterChain tokenExchangeChain(HttpSecurity http) throws Exception {
+        http
+            .securityMatcher("/api/v2/auth/token")
+            .cors(Customizer.withDefaults())
+            .csrf(AbstractHttpConfigurer::disable) // NOSONAR: jwt-stateless-no-csrf-risk
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+            // Sin oauth2ResourceServer: el controller decodifica el Google token manualmente
+        return http.build();
+    }
+
+    // Chain 2 (Orden 2): todos los demas endpoints — valida dpt_token (HS256/JWT_SECRET).
     // Fase 1a: permitAll() — no rompe endpoints existentes.
     // Fase 1b (siguiente commit): restringir endpoints con .authenticated()
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    @Order(2)
+    public SecurityFilterChain mainChain(HttpSecurity http) throws Exception {
         http
             .cors(Customizer.withDefaults())
             // CSRF deshabilitado intencionalmente: API stateless con JWT en Authorization header.
@@ -51,14 +72,24 @@ public class SecurityConfig {
             .sessionManagement(session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
-            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(systemJwtDecoder())));
         return http.build();
     }
 
-    // Decodifica tokens Google ID (valida firma via JWKS publico de Google)
-    @Bean
-    public JwtDecoder jwtDecoder() {
+    // Decodifica tokens Google ID (RS256, valida firma via JWKS publico de Google).
+    // Usado exclusivamente por TokenInterchangeRest para validar el token entrante de Google.
+    @Bean("googleJwtDecoder")
+    public JwtDecoder googleJwtDecoder() {
         return NimbusJwtDecoder.withJwkSetUri(googleJwksUri).build();
+    }
+
+    // Decodifica los JWT propios del sistema (HS256, firmados con JWT_SECRET).
+    // Usado por mainChain para validar el dpt_token que emite TokenServicio.
+    @Bean("systemJwtDecoder")
+    public JwtDecoder systemJwtDecoder() {
+        byte[] keyBytes = Base64.getDecoder().decode(jwtSecret);
+        SecretKey key = new SecretKeySpec(keyBytes, "HmacSHA256");
+        return NimbusJwtDecoder.withSecretKey(key).macAlgorithm(MacAlgorithm.HS256).build();
     }
 
     // Firma los JWT propios del sistema con HMAC-SHA256

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/modelo/Perfil.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/modelo/Perfil.java
@@ -1,7 +1,5 @@
 package co.edu.unicauca.deporteParaTodos.dominio.modelo;
 
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.PerfilDto;
-import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.PerfilEntidad;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,41 +30,4 @@ public class Perfil {
     private String tipoAlumno;
 
     private String alumnoCodigo;
-
-    public static Perfil fabricarDeEntidad(PerfilEntidad entidad){
-        try{
-            Perfil perfil = new Perfil();
-            perfil.setId(entidad.getPerf_id());
-            perfil.setNombre(entidad.getPerf_nombre());
-            perfil.setTipoId(entidad.getPerf_tipo());
-            perfil.setSexo(entidad.getPerf_Sexo());
-            perfil.setCorreo(entidad.getPerfcorreo());
-            perfil.setImagen(entidad.getPerf_imagen());
-            perfil.setRol(null);
-            perfil.setFacultad(null);
-            perfil.setTipoAlumno(null);
-            return perfil;
-        }catch (Exception e){
-            return null;
-        }
-    }
-
-    public static Perfil fabricarDeDto(PerfilDto dto) {
-        try {
-            Perfil perfil = new Perfil();
-            perfil.setId(dto.getId());
-            perfil.setNombre(dto.getNombre());
-            perfil.setCorreo(dto.getCorreo());
-            perfil.setTipoId(dto.getTipoId());
-            perfil.setSexo(dto.getSexo());
-            perfil.setRol(dto.getRole());
-            perfil.setFacultad(dto.getFacultad());
-            perfil.setTipoAlumno(dto.getTipoAlumno());
-            perfil.setAlumnoCodigo(dto.getAlumnoCodigo());
-            perfil.setImagen(null);
-            return perfil;
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/AutenticacionServicio.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/AutenticacionServicio.java
@@ -1,7 +1,5 @@
 package co.edu.unicauca.deporteParaTodos.dominio.servicios;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -16,21 +14,12 @@ import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.PerfilMapper;
 @Service
 public class AutenticacionServicio implements IAutenticacionServicio{
 
-    // [DIAG-TEMP] eliminar tras validacion
-    private static final Logger LOGGER = LoggerFactory.getLogger(AutenticacionServicio.class);
-
     @Autowired
     private IPerfilGateway gatePerfil;
 
     @Override
     public PerfilDto login(String email) {
         Perfil perfil = gatePerfil.obtenerUsuario(email);
-        // [DIAG-TEMP] Perfil crudo de BD antes de conversion a DTO
-        LOGGER.info("[DIAG] obtenerUsuario({}) → id={} correo={} rol={}",
-                email,
-                perfil != null ? perfil.getId() : "NULL",
-                perfil != null ? perfil.getCorreo() : "NULL",
-                perfil != null ? perfil.getRol() : "NULL");
         if(perfil==null){
             throw new NoExisteExcepcion();
         }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/AutenticacionServicio.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/AutenticacionServicio.java
@@ -1,5 +1,7 @@
 package co.edu.unicauca.deporteParaTodos.dominio.servicios;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -7,23 +9,32 @@ import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.IAuten
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosSalida.IPerfilGateway;
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Perfil;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.PerfilDto;
-import co.edu.unicauca.deporteParaTodos.dominio.excepciones.ErrorInternoException;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.YaExisteElementoExcepcion;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.PerfilMapper;
 
 @Service
 public class AutenticacionServicio implements IAutenticacionServicio{
+
+    // [DIAG-TEMP] eliminar tras validacion
+    private static final Logger LOGGER = LoggerFactory.getLogger(AutenticacionServicio.class);
+
     @Autowired
     private IPerfilGateway gatePerfil;
 
     @Override
     public PerfilDto login(String email) {
         Perfil perfil = gatePerfil.obtenerUsuario(email);
+        // [DIAG-TEMP] Perfil crudo de BD antes de conversion a DTO
+        LOGGER.info("[DIAG] obtenerUsuario({}) → id={} correo={} rol={}",
+                email,
+                perfil != null ? perfil.getId() : "NULL",
+                perfil != null ? perfil.getCorreo() : "NULL",
+                perfil != null ? perfil.getRol() : "NULL");
         if(perfil==null){
             throw new NoExisteExcepcion();
         }
-        PerfilDto dto = PerfilDto.fabricarDeModelo(perfil);
-        return dto;
+        return PerfilMapper.toDto(perfil);
     }
 
     @Override
@@ -31,16 +42,9 @@ public class AutenticacionServicio implements IAutenticacionServicio{
         if (gatePerfil.existePerfil(datosPerfil.getId())) {
             throw new YaExisteElementoExcepcion("El perfil con la identificacion ya se encuentra registrado");
         }
-        Perfil perfil = Perfil.fabricarDeDto(datosPerfil);
-        if (perfil == null) {
-            throw new ErrorInternoException();
-        }
+        Perfil perfil = PerfilMapper.fromDto(datosPerfil);
         Perfil perfilRegistrado = gatePerfil.registrarAlumno(perfil);
-        PerfilDto respuesta = PerfilDto.fabricarDeModelo(perfilRegistrado);
-        if (respuesta == null) {
-            throw new ErrorInternoException();
-        }
-        return respuesta;
+        return PerfilMapper.toDto(perfilRegistrado);
     }
 
     

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/InstructorServicio.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/InstructorServicio.java
@@ -13,6 +13,7 @@ import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresP
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.PerfilDto;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.ErrorInternoException;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.ListadoVacioExcepcion;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.PerfilMapper;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.YaExisteElementoExcepcion;
 
@@ -74,10 +75,7 @@ public class InstructorServicio implements IInstructorServicio {
         }
 
         // Convertir DTO a modelo de dominio
-        Perfil perfil = Perfil.fabricarDeDto(perfilDto);
-        if (perfil == null) {
-            throw new ErrorInternoException("Error al procesar los datos del instructor");
-        }
+        Perfil perfil = PerfilMapper.fromDto(perfilDto);
 
         // Llamar al gateway para registrar el instructor atomicamente
         // (crea perfil + alumno + instructor en una transacción)

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/DTOs/PerfilDto.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/DTOs/PerfilDto.java
@@ -1,6 +1,5 @@
 package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs;
 
-import co.edu.unicauca.deporteParaTodos.dominio.modelo.Perfil;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -39,20 +38,4 @@ public class PerfilDto {
 
     private String alumnoCodigo;
 
-    public static PerfilDto fabricarDeModelo(Perfil perfil){
-        try{
-            PerfilDto dto = new PerfilDto();
-            dto.setNombre(perfil.getNombre());
-            dto.setId(perfil.getId());
-            dto.setCorreo(perfil.getCorreo());
-            dto.setRole(perfil.getRol());
-            dto.setSexo(perfil.getSexo());
-            dto.setTipoId(perfil.getTipoId());
-            dto.setFacultad(perfil.getFacultad());
-            dto.setTipoAlumno(perfil.getTipoAlumno());
-            return dto;
-        }catch(Exception e){
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/TokenInterchangeRest.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/TokenInterchangeRest.java
@@ -7,8 +7,6 @@ import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresP
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,9 +21,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("api/v2/auth")
 public class TokenInterchangeRest {
-
-    // [DIAG-TEMP] eliminar tras validacion
-    private static final Logger LOGGER = LoggerFactory.getLogger(TokenInterchangeRest.class);
 
     private final JwtDecoder googleDecoder;
     private final IAutenticacionServicio autenticacionServicio;
@@ -69,12 +64,6 @@ public class TokenInterchangeRest {
         // autenticacionServicio.login lanza NoExisteExcepcion (→ 404 via handler global)
         // si el correo no esta registrado en el sistema
         PerfilDto perfil = autenticacionServicio.login(email);
-        // [DIAG-TEMP] PerfilDto final justo antes de serializar a JSON
-        LOGGER.info("[DIAG] intercambiarToken email={} → dto.id={} dto.correo={} dto.role={}",
-                email,
-                perfil != null ? perfil.getId() : "NULL",
-                perfil != null ? perfil.getCorreo() : "NULL",
-                perfil != null ? perfil.getRole() : "NULL");
         String token = tokenServicio.emitirToken(perfil);
         return ResponseEntity.ok(new TokenResponseDto(token, perfil));
     }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/TokenInterchangeRest.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresPrimarios/adaptadorRest/api/TokenInterchangeRest.java
@@ -7,6 +7,9 @@ import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresP
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -21,11 +24,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("api/v2/auth")
 public class TokenInterchangeRest {
 
+    // [DIAG-TEMP] eliminar tras validacion
+    private static final Logger LOGGER = LoggerFactory.getLogger(TokenInterchangeRest.class);
+
     private final JwtDecoder googleDecoder;
     private final IAutenticacionServicio autenticacionServicio;
     private final TokenServicio tokenServicio;
 
-    public TokenInterchangeRest(JwtDecoder googleDecoder,
+    public TokenInterchangeRest(@Qualifier("googleJwtDecoder") JwtDecoder googleDecoder,
                                 IAutenticacionServicio autenticacionServicio,
                                 TokenServicio tokenServicio) {
         this.googleDecoder = googleDecoder;
@@ -63,6 +69,12 @@ public class TokenInterchangeRest {
         // autenticacionServicio.login lanza NoExisteExcepcion (→ 404 via handler global)
         // si el correo no esta registrado en el sistema
         PerfilDto perfil = autenticacionServicio.login(email);
+        // [DIAG-TEMP] PerfilDto final justo antes de serializar a JSON
+        LOGGER.info("[DIAG] intercambiarToken email={} → dto.id={} dto.correo={} dto.role={}",
+                email,
+                perfil != null ? perfil.getId() : "NULL",
+                perfil != null ? perfil.getCorreo() : "NULL",
+                perfil != null ? perfil.getRole() : "NULL");
         String token = tokenServicio.emitirToken(perfil);
         return ResponseEntity.ok(new TokenResponseDto(token, perfil));
     }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/entidades/AlumnoEntidad.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/entidades/AlumnoEntidad.java
@@ -3,7 +3,6 @@ package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadores
 import java.util.ArrayList;
 import java.util.List;
 
-import co.edu.unicauca.deporteParaTodos.dominio.modelo.Perfil;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,16 +41,4 @@ public class AlumnoEntidad {
     @Column(name= "META_ELIMINADO")
     private Integer eliminado;
 
-    public static AlumnoEntidad fabricarDePerfil(Perfil perfil, Integer eliminado) {
-        try {
-            AlumnoEntidad entidad = new AlumnoEntidad();
-            entidad.setIdPerfil(perfil.getId());
-            entidad.setAlm_codigo(perfil.getAlumnoCodigo());
-            entidad.setTipoAlumno(perfil.getTipoAlumno());
-            entidad.setEliminado(eliminado);
-            return entidad;
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/entidades/PerfilEntidad.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/entidades/PerfilEntidad.java
@@ -1,6 +1,5 @@
 package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades;
 
-import co.edu.unicauca.deporteParaTodos.dominio.modelo.Perfil;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -39,19 +38,4 @@ public class PerfilEntidad {
     @Column(name ="META_ELIMINADO")
     private Integer eliminado;
 
-    public static PerfilEntidad fabricarDeModelo(Perfil perfil, int eliminado){
-        try{
-            PerfilEntidad entidad = new PerfilEntidad();
-            entidad.setEliminado(eliminado);
-            entidad.setPerf_id(perfil.getId());
-            entidad.setPerf_nombre(perfil.getNombre());
-            entidad.setPerf_Sexo(perfil.getSexo());
-            entidad.setPerf_tipo(perfil.getTipoId());
-            entidad.setPerfcorreo(perfil.getCorreo());
-            entidad.setPerf_imagen(perfil.getImagen());
-            return entidad;
-        }catch(Exception e){
-            return null;
-        }
-    }
 }

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/InstructorGateway.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/InstructorGateway.java
@@ -19,6 +19,7 @@ import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresS
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.repositorios.IPerfilRepositorio;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
 import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoImplementadoException;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.PerfilMapper;
 
 @Service
 public class InstructorGateway implements IInstructorGateway {
@@ -42,7 +43,7 @@ public class InstructorGateway implements IInstructorGateway {
         instructor.setInst_codigo(entidad.getIdPerfil());
 
         if (entidad.getPerfil() != null) {
-            instructor.setPerfil(Perfil.fabricarDeEntidad(entidad.getPerfil()));
+            instructor.setPerfil(PerfilMapper.toDominio(entidad.getPerfil()));
         }
 
         return instructor;
@@ -95,7 +96,7 @@ public class InstructorGateway implements IInstructorGateway {
     @Override
     public Instructor registrarInstructor(Perfil perfil, String tipoAlumno) {
         // [1] Crear perfil
-        PerfilEntidad entidadPerfil = PerfilEntidad.fabricarDeModelo(perfil, 0);
+        PerfilEntidad entidadPerfil = PerfilMapper.toEntidad(perfil);
         PerfilEntidad perfilGuardado = repoPerfil.save(entidadPerfil);
         String perfilId = perfilGuardado.getPerf_id();
 
@@ -115,7 +116,7 @@ public class InstructorGateway implements IInstructorGateway {
         // Construir objeto de dominio para retornar
         Instructor instructorRegistrado = new Instructor();
         instructorRegistrado.setInst_codigo(instructorGuardado.getIdPerfil());
-        instructorRegistrado.setPerfil(Perfil.fabricarDeEntidad(perfilGuardado));
+        instructorRegistrado.setPerfil(PerfilMapper.toDominio(perfilGuardado));
         instructorRegistrado.getPerfil().setTipoAlumno(tipoAlumno);
 
         return instructorRegistrado;

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/PerfilGateway.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/PerfilGateway.java
@@ -19,9 +19,9 @@ import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresS
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.repositorios.IInstructorRepositorio;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.repositorios.IPerfilRepositorio;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.DependenciaFallida;
-import co.edu.unicauca.deporteParaTodos.infraestructura.controladorExcepciones.excepciones.NoConvertibleException;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
 import co.edu.unicauca.deporteParaTodos.dominio.excepciones.YaExisteElementoExcepcion;
+import co.edu.unicauca.deporteParaTodos.infraestructura.mappers.PerfilMapper;
 
 @Service
 public class PerfilGateway implements IPerfilGateway {
@@ -61,32 +61,15 @@ public class PerfilGateway implements IPerfilGateway {
 
     @Override
     public Perfil insertarPerfil(Perfil perfil) {
-        //verificar insercion
         if(existePerfil(perfil.getId())){
             throw new YaExisteElementoExcepcion("El perfil con la identificacion ya se encuentra registrado");
         }
-
-        //verificar imagen
         if(!repoImagen.existsById(perfil.getImagen())){
             throw new DependenciaFallida("la imgen no se encuentra registrada");
         }
-
-        //conversion de datos
-        PerfilEntidad entidadInsertar = PerfilEntidad.fabricarDeModelo(perfil, 0);
-        if(entidadInsertar==null){
-            throw new NoConvertibleException();
-        }
-
-        //insercion
+        PerfilEntidad entidadInsertar = PerfilMapper.toEntidad(perfil);
         PerfilEntidad guardado = repoPerfil.save(entidadInsertar);
-
-        //conversion
-        Perfil perfilCreado = Perfil.fabricarDeEntidad(guardado);
-        if(perfilCreado == null){
-            throw new InternalError("No se ha logrado retornar la respuesta desde gateway");
-        }
-        
-        return perfilCreado;
+        return PerfilMapper.toDominio(guardado);
     }
 
     @Override
@@ -95,15 +78,13 @@ public class PerfilGateway implements IPerfilGateway {
             throw new YaExisteElementoExcepcion("El perfil con la identificacion ya se encuentra registrado");
         }
 
-        PerfilEntidad entidadPerfil = PerfilEntidad.fabricarDeModelo(perfil, 0);
-        if (entidadPerfil == null) {
-            throw new NoConvertibleException();
-        }
+        PerfilEntidad entidadPerfil = PerfilMapper.toEntidad(perfil);
 
-        AlumnoEntidad entidadAlumno = AlumnoEntidad.fabricarDePerfil(perfil, 0);
-        if (entidadAlumno == null) {
-            throw new NoConvertibleException();
-        }
+        AlumnoEntidad entidadAlumno = new AlumnoEntidad();
+        entidadAlumno.setIdPerfil(perfil.getId());
+        entidadAlumno.setAlm_codigo(perfil.getAlumnoCodigo());
+        entidadAlumno.setTipoAlumno(perfil.getTipoAlumno());
+        entidadAlumno.setEliminado(0);
 
         PerfilEntidad perfilGuardado = repoPerfil.save(entidadPerfil);
         AlumnoEntidad alumnoGuardado = repoAlumno.save(entidadAlumno);
@@ -112,10 +93,7 @@ public class PerfilGateway implements IPerfilGateway {
             throw new InternalError("No se ha logrado registrar el alumno");
         }
 
-        Perfil perfilRegistrado = Perfil.fabricarDeEntidad(perfilGuardado);
-        if (perfilRegistrado == null) {
-            throw new NoConvertibleException();
-        }
+        Perfil perfilRegistrado = PerfilMapper.toDominio(perfilGuardado);
         perfilRegistrado.setRol(Roles.ALUMNO.getValor());
         perfilRegistrado.setTipoAlumno(alumnoGuardado.getTipoAlumno());
         perfilRegistrado.setFacultad(null);
@@ -177,7 +155,7 @@ public class PerfilGateway implements IPerfilGateway {
         List<PerfilEntidad> perfiles = repoPerfil.findByPerfcorreo(email);
         if(perfiles.size()>0){
             PerfilEntidad entidad = perfiles.get(0);
-            Perfil perfil = Perfil.fabricarDeEntidad(entidad);
+            Perfil perfil = PerfilMapper.toDominio(entidad);
             String id = perfil.getId();
             if(repoCoordinador.existsById(id)){
                 perfil.setRol(Roles.ADMINISTRADOR.getValor());

--- a/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/PerfilMapper.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/PerfilMapper.java
@@ -1,0 +1,82 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.mappers;
+
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoProcesableEntidadException;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Perfil;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.PerfilDto;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.PerfilEntidad;
+
+public class PerfilMapper {
+
+    public static Perfil toDominio(PerfilEntidad entidad) {
+        // rol, facultad y tipoAlumno se hardcodean null; obtenerUsuario() los asigna
+        // después de esta conversión según consultas adicionales a BD
+        try {
+            Perfil perfil = new Perfil();
+            perfil.setId(entidad.getPerf_id());
+            perfil.setNombre(entidad.getPerf_nombre());
+            perfil.setCorreo(entidad.getPerfcorreo());      // sin guión bajo (campo DB: perf_correo)
+            perfil.setImagen(entidad.getPerf_imagen());
+            perfil.setTipoId(entidad.getPerf_tipo());
+            perfil.setSexo(entidad.getPerf_Sexo());         // getter con S mayúscula
+            perfil.setRol(null);
+            perfil.setFacultad(null);
+            perfil.setTipoAlumno(null);
+            return perfil;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir PerfilEntidad a dominio: " + e.getMessage());
+        }
+    }
+
+    public static PerfilEntidad toEntidad(Perfil perfil) {
+        try {
+            PerfilEntidad entidad = new PerfilEntidad();
+            entidad.setPerf_id(perfil.getId());
+            entidad.setPerf_nombre(perfil.getNombre());
+            entidad.setPerfcorreo(perfil.getCorreo());       // sin guión bajo
+            entidad.setPerf_imagen(perfil.getImagen());
+            entidad.setPerf_tipo(perfil.getTipoId());
+            entidad.setPerf_Sexo(perfil.getSexo());          // setter con S mayúscula
+            entidad.setEliminado(0);
+            return entidad;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir Perfil a entidad: " + e.getMessage());
+        }
+    }
+
+    public static PerfilDto toDto(Perfil perfil) {
+        try {
+            PerfilDto dto = new PerfilDto();
+            dto.setId(perfil.getId());
+            dto.setNombre(perfil.getNombre());
+            dto.setCorreo(perfil.getCorreo());
+            dto.setRole(perfil.getRol());           // ASIMÉTRICO: rol (dominio) → role (DTO)
+            dto.setSexo(perfil.getSexo());
+            dto.setTipoId(perfil.getTipoId());
+            dto.setFacultad(perfil.getFacultad());
+            dto.setTipoAlumno(perfil.getTipoAlumno());
+            // alumnoCodigo no se mapea — consistente con comportamiento de fabricarDeModelo anterior
+            return dto;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir Perfil a PerfilDto: " + e.getMessage());
+        }
+    }
+
+    public static Perfil fromDto(PerfilDto dto) {
+        try {
+            Perfil perfil = new Perfil();
+            perfil.setId(dto.getId());
+            perfil.setNombre(dto.getNombre());
+            perfil.setCorreo(dto.getCorreo());
+            perfil.setTipoId(dto.getTipoId());
+            perfil.setSexo(dto.getSexo());
+            perfil.setRol(dto.getRole());           // ASIMÉTRICO: role (DTO) → rol (dominio)
+            perfil.setFacultad(dto.getFacultad());
+            perfil.setTipoAlumno(dto.getTipoAlumno());
+            perfil.setAlumnoCodigo(dto.getAlumnoCodigo());
+            perfil.setImagen(null);
+            return perfil;
+        } catch (Exception e) {
+            throw new NoProcesableEntidadException("No fue posible convertir PerfilDto a dominio: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/configurations/SecurityConfigTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/configurations/SecurityConfigTest.java
@@ -3,6 +3,7 @@ package co.edu.unicauca.deporteParaTodos.configurations;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.cors.CorsConfiguration;
@@ -56,5 +57,11 @@ class SecurityConfigTest {
     void jwtEncoder_seConstruyeConSecretoBase64Valido() {
         JwtEncoder encoder = securityConfig.jwtEncoder();
         assertNotNull(encoder, "jwtEncoder debe construirse sin excepcion con un secreto Base64 valido");
+    }
+
+    @Test
+    void systemJwtDecoder_seConstruyeConSecretoHS256Valido() {
+        JwtDecoder decoder = securityConfig.systemJwtDecoder();
+        assertNotNull(decoder, "systemJwtDecoder debe construirse sin excepcion con el mismo secreto Base64 que usa el encoder");
     }
 }

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/AutenticacionServicioTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/AutenticacionServicioTest.java
@@ -1,0 +1,95 @@
+package co.edu.unicauca.deporteParaTodos.dominio.servicios;
+
+import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosSalida.IPerfilGateway;
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.YaExisteElementoExcepcion;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Perfil;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.PerfilDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AutenticacionServicioTest {
+
+    @Mock
+    private IPerfilGateway gatePerfil;
+
+    @InjectMocks
+    private AutenticacionServicio autenticacionServicio;
+
+    private Perfil perfilBase() {
+        Perfil p = new Perfil();
+        p.setId("12345678");
+        p.setNombre("Juan García");
+        p.setCorreo("juan@unicauca.edu.co");
+        p.setTipoId("CC");
+        p.setSexo("M");
+        p.setRol("ALUMNO");
+        p.setFacultad("Ingeniería");
+        p.setTipoAlumno("Regular");
+        return p;
+    }
+
+    private PerfilDto dtoBase() {
+        PerfilDto d = new PerfilDto();
+        d.setId("12345678");
+        d.setNombre("Juan García");
+        d.setCorreo("juan@unicauca.edu.co");
+        d.setTipoId("CC");
+        d.setSexo("M");
+        d.setRole("ALUMNO");
+        d.setFacultad("Ingeniería");
+        d.setTipoAlumno("Regular");
+        return d;
+    }
+
+    @Test
+    void login_emailExistente_retornaPerfilDto() {
+        when(gatePerfil.obtenerUsuario("juan@unicauca.edu.co")).thenReturn(perfilBase());
+
+        PerfilDto resultado = autenticacionServicio.login("juan@unicauca.edu.co");
+
+        assertNotNull(resultado);
+        assertEquals("12345678", resultado.getId());
+        assertEquals("ALUMNO",   resultado.getRole());
+        verify(gatePerfil).obtenerUsuario("juan@unicauca.edu.co");
+    }
+
+    @Test
+    void login_emailNoExistente_lanzaNoExisteExcepcion() {
+        when(gatePerfil.obtenerUsuario(anyString())).thenReturn(null);
+
+        assertThrows(NoExisteExcepcion.class,
+                () -> autenticacionServicio.login("desconocido@externo.com"));
+    }
+
+    @Test
+    void registrarAlumno_perfilNoExistente_retornaPerfilDto() {
+        when(gatePerfil.existePerfil(anyString())).thenReturn(false);
+        when(gatePerfil.registrarAlumno(any(Perfil.class))).thenReturn(perfilBase());
+
+        PerfilDto resultado = autenticacionServicio.registrarAlumno(dtoBase());
+
+        assertNotNull(resultado);
+        assertEquals("12345678", resultado.getId());
+        assertEquals("ALUMNO",   resultado.getRole());
+        verify(gatePerfil).registrarAlumno(any(Perfil.class));
+    }
+
+    @Test
+    void registrarAlumno_perfilYaExistente_lanzaYaExisteElementoExcepcion() {
+        when(gatePerfil.existePerfil(anyString())).thenReturn(true);
+
+        assertThrows(YaExisteElementoExcepcion.class,
+                () -> autenticacionServicio.registrarAlumno(dtoBase()));
+
+        verify(gatePerfil, never()).registrarAlumno(any());
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/InstructorServicioTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/dominio/servicios/InstructorServicioTest.java
@@ -1,6 +1,9 @@
 package co.edu.unicauca.deporteParaTodos.dominio.servicios;
 
 import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosSalida.IInstructorGateway;
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.ListadoVacioExcepcion;
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.YaExisteElementoExcepcion;
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Instructor;
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Perfil;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.InstructorDto;
@@ -10,6 +13,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -24,14 +30,88 @@ class InstructorServicioTest {
     @InjectMocks
     private InstructorServicio instructorServicio;
 
+    private static final String ID      = "98765432";
+    private static final String NOMBRE  = "Prof. García";
+    private static final String CORREO  = "garcia@unicauca.edu.co";
+    private static final String TIPO_ID = "CC";
+    private static final String SEXO    = "M";
+
+    private Instructor instructorConPerfil() {
+        Perfil perfil = new Perfil();
+        perfil.setId(ID);
+        perfil.setNombre(NOMBRE);
+        perfil.setCorreo(CORREO);
+        perfil.setSexo(SEXO);
+        Instructor inst = new Instructor();
+        inst.setInst_codigo(ID);
+        inst.setPerfil(perfil);
+        return inst;
+    }
+
+    private PerfilDto dtoBase() {
+        PerfilDto dto = new PerfilDto();
+        dto.setId(ID);
+        dto.setNombre(NOMBRE);
+        dto.setCorreo(CORREO);
+        dto.setTipoId(TIPO_ID);
+        dto.setSexo(SEXO);
+        dto.setTipoAlumno("Instructor");
+        return dto;
+    }
+
+    // ── obtenerInstructores ─────────────────────────────────────────────────
+
+    @Test
+    void obtenerInstructores_conDatos_retornaListaDtos() {
+        when(instructorsGateway.obtenerInstructores()).thenReturn(List.of(instructorConPerfil()));
+
+        List<InstructorDto> resultado = instructorServicio.obtenerInstructores();
+
+        assertNotNull(resultado);
+        assertEquals(1, resultado.size());
+        assertEquals(ID,     resultado.get(0).getId());
+        assertEquals(CORREO, resultado.get(0).getCorreo());
+    }
+
+    @Test
+    void obtenerInstructores_sinDatos_lanzaListadoVacioExcepcion() {
+        when(instructorsGateway.obtenerInstructores()).thenReturn(List.of());
+
+        assertThrows(ListadoVacioExcepcion.class,
+                () -> instructorServicio.obtenerInstructores());
+    }
+
+    // ── obtenerInstructor ───────────────────────────────────────────────────
+
+    @Test
+    void obtenerInstructor_existente_retornaInstructorDto() {
+        when(instructorsGateway.obtenerInstructor(ID)).thenReturn(Optional.of(instructorConPerfil()));
+
+        InstructorDto resultado = instructorServicio.obtenerInstructor(ID);
+
+        assertNotNull(resultado);
+        assertEquals(ID,     resultado.getId());
+        assertEquals(NOMBRE, resultado.getNombre());
+    }
+
+    @Test
+    void obtenerInstructor_noExistente_lanzaNoExisteExcepcion() {
+        when(instructorsGateway.obtenerInstructor(anyString())).thenReturn(Optional.empty());
+
+        assertThrows(NoExisteExcepcion.class,
+                () -> instructorServicio.obtenerInstructor("desconocido"));
+    }
+
+    // ── registrarInstructor ─────────────────────────────────────────────────
+
     @Test
     void registrarInstructor_sinAlumnoCodigo_seRegistraCorrectamente() {
         PerfilDto dto = new PerfilDto();
-        dto.setId("98765432");
-        dto.setNombre("Prof. García");
-        dto.setCorreo("garcia@unicauca.edu.co");
-        dto.setTipoId("CC");
-        dto.setSexo("M");
+        dto.setId(ID);
+        dto.setNombre(NOMBRE);
+        dto.setCorreo(CORREO);
+        dto.setTipoId(TIPO_ID);
+        dto.setSexo(SEXO);
         dto.setTipoAlumno("Instructor");
         // alumnoCodigo NOT set — remains null (regression: SCRUM-137)
 
@@ -43,5 +123,15 @@ class InstructorServicioTest {
 
         assertNotNull(resultado);
         verify(instructorsGateway).registrarInstructor(any(Perfil.class), eq("Instructor"));
+    }
+
+    @Test
+    void registrarInstructor_yaExistente_lanzaYaExisteElementoExcepcion() {
+        when(instructorsGateway.existeInstructor(ID)).thenReturn(true);
+
+        assertThrows(YaExisteElementoExcepcion.class,
+                () -> instructorServicio.registrarInstructor(dtoBase()));
+
+        verify(instructorsGateway, never()).registrarInstructor(any(), any());
     }
 }

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/InstructorGatewayTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/InstructorGatewayTest.java
@@ -1,0 +1,157 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.gateway;
+
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoExisteExcepcion;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Instructor;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Perfil;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.AlumnoEntidad;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.InstructorEntidad;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.PerfilEntidad;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.repositorios.IAlumnoRepositorio;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.repositorios.IInstructorRepositorio;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.repositorios.IPerfilRepositorio;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InstructorGatewayTest {
+
+    @Mock
+    private IInstructorRepositorio repoInstructor;
+
+    @Mock
+    private IPerfilRepositorio repoPerfil;
+
+    @Mock
+    private IAlumnoRepositorio repoAlumno;
+
+    @Mock
+    private ModelMapper mapper;
+
+    @InjectMocks
+    private InstructorGateway instructorGateway;
+
+    private static final String PERF_ID  = "12345678";
+    private static final String NOMBRE   = "Prof. García";
+    private static final String CORREO   = "garcia@unicauca.edu.co";
+    private static final String SEXO     = "M";
+    private static final String TIPO_ALM = "Instructor";
+
+    private PerfilEntidad perfilEntidadBase() {
+        PerfilEntidad e = new PerfilEntidad();
+        e.setPerf_id(PERF_ID);
+        e.setPerf_nombre(NOMBRE);
+        e.setPerfcorreo(CORREO);
+        e.setPerf_tipo("CC");
+        e.setPerf_Sexo(SEXO);
+        e.setEliminado(0);
+        return e;
+    }
+
+    private InstructorEntidad instructorEntidadBase() {
+        InstructorEntidad e = new InstructorEntidad();
+        e.setIdPerfil(PERF_ID);
+        e.setEliminado(0);
+        e.setPerfil(perfilEntidadBase());
+        return e;
+    }
+
+    private Perfil perfilBase() {
+        Perfil p = new Perfil();
+        p.setId(PERF_ID);
+        p.setNombre(NOMBRE);
+        p.setCorreo(CORREO);
+        p.setTipoId("CC");
+        p.setSexo(SEXO);
+        return p;
+    }
+
+    @Test
+    void obtenerInstructores_retornaListaConInstructor() {
+        when(repoInstructor.findAll()).thenReturn(List.of(instructorEntidadBase()));
+
+        List<Instructor> resultado = instructorGateway.obtenerInstructores();
+
+        assertNotNull(resultado);
+        assertEquals(1, resultado.size());
+        assertNotNull(resultado.get(0).getPerfil());
+        assertEquals(PERF_ID, resultado.get(0).getPerfil().getId());
+        assertEquals(CORREO,  resultado.get(0).getPerfil().getCorreo());
+    }
+
+    @Test
+    void obtenerInstructor_existente_retornaOptionalConInstructor() {
+        when(repoInstructor.existsById(PERF_ID)).thenReturn(true);
+        when(repoInstructor.findById(PERF_ID)).thenReturn(Optional.of(instructorEntidadBase()));
+
+        Optional<Instructor> resultado = instructorGateway.obtenerInstructor(PERF_ID);
+
+        assertTrue(resultado.isPresent());
+        assertEquals(PERF_ID, resultado.get().getPerfil().getId());
+    }
+
+    @Test
+    void obtenerInstructor_noExistente_retornaEmpty() {
+        when(repoInstructor.existsById(anyString())).thenReturn(false);
+
+        Optional<Instructor> resultado = instructorGateway.obtenerInstructor("desconocido");
+
+        assertTrue(resultado.isEmpty());
+        verify(repoInstructor, never()).findById(any());
+    }
+
+    @Test
+    void eliminarInstructor_existente_eliminaYRetornaInstructor() {
+        InstructorEntidad entidad = instructorEntidadBase();
+        when(repoInstructor.findById(PERF_ID)).thenReturn(Optional.of(entidad));
+        when(mapper.map(entidad, Instructor.class)).thenReturn(new Instructor());
+
+        Instructor resultado = instructorGateway.eliminarInstructor(PERF_ID);
+
+        assertNotNull(resultado);
+        verify(repoInstructor).delete(entidad);
+    }
+
+    @Test
+    void eliminarInstructor_noExistente_lanzaNoExisteExcepcion() {
+        when(repoInstructor.findById(anyString())).thenReturn(Optional.empty());
+
+        assertThrows(NoExisteExcepcion.class,
+                () -> instructorGateway.eliminarInstructor("desconocido"));
+
+        verify(repoInstructor, never()).delete(any());
+    }
+
+    @Test
+    void registrarInstructor_guardaPerfilAlumnoEInstructor() {
+        PerfilEntidad perfilGuardado = perfilEntidadBase();
+        InstructorEntidad instructorGuardado = new InstructorEntidad();
+        instructorGuardado.setIdPerfil(PERF_ID);
+
+        when(repoPerfil.save(any(PerfilEntidad.class))).thenReturn(perfilGuardado);
+        when(repoAlumno.save(any(AlumnoEntidad.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(repoInstructor.save(any(InstructorEntidad.class))).thenReturn(instructorGuardado);
+
+        Instructor resultado = instructorGateway.registrarInstructor(perfilBase(), TIPO_ALM);
+
+        assertNotNull(resultado);
+        assertEquals(PERF_ID, resultado.getInst_codigo());
+        assertNotNull(resultado.getPerfil());
+        assertEquals(CORREO, resultado.getPerfil().getCorreo());
+        assertEquals(TIPO_ALM, resultado.getPerfil().getTipoAlumno());
+        verify(repoPerfil).save(any(PerfilEntidad.class));
+        verify(repoAlumno).save(any(AlumnoEntidad.class));
+        verify(repoInstructor).save(any(InstructorEntidad.class));
+    }
+}

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/PerfilGatewayTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/adaptadores/adaptadoresSecundarios/persistenciaSQL/gateway/PerfilGatewayTest.java
@@ -1,5 +1,7 @@
 package co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.gateway;
 
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.DependenciaFallida;
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.YaExisteElementoExcepcion;
 import co.edu.unicauca.deporteParaTodos.dominio.modelo.Perfil;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.AlumnoEntidad;
 import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.PerfilEntidad;
@@ -16,8 +18,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
+import java.util.List;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,21 +50,170 @@ class PerfilGatewayTest {
     @InjectMocks
     private PerfilGateway perfilGateway;
 
+    private static final String  ID       = "12345678";
+    private static final String  NOMBRE   = "Juan Test";
+    private static final String  CORREO   = "juan@unicauca.edu.co";
+    private static final Integer IMAGEN   = 1;
+    private static final String  TIPO_ID  = "CC";
+    private static final String  SEXO     = "M";
+    private static final String  TIPO_ALM = "Regular";
+    private static final String  ALM_COD  = "2025-CIEN-001";
+
+    private Perfil perfilBase() {
+        Perfil p = new Perfil();
+        p.setId(ID);
+        p.setNombre(NOMBRE);
+        p.setCorreo(CORREO);
+        p.setImagen(IMAGEN);
+        p.setTipoId(TIPO_ID);
+        p.setSexo(SEXO);
+        p.setTipoAlumno(TIPO_ALM);
+        p.setAlumnoCodigo(ALM_COD);
+        return p;
+    }
+
+    private PerfilEntidad entidadBase() {
+        PerfilEntidad e = new PerfilEntidad();
+        e.setPerf_id(ID);
+        e.setPerf_nombre(NOMBRE);
+        e.setPerfcorreo(CORREO);
+        e.setPerf_imagen(IMAGEN);
+        e.setPerf_tipo(TIPO_ID);
+        e.setPerf_Sexo(SEXO);
+        e.setEliminado(0);
+        return e;
+    }
+
+    // ── insertarPerfil ──────────────────────────────────────────────────────
+
+    @Test
+    void insertarPerfil_perfilNoExistente_retornaPerfil() {
+        when(repoPerfil.existsById(ID)).thenReturn(false);
+        when(repoImagen.existsById(IMAGEN)).thenReturn(true);
+        when(repoPerfil.save(any(PerfilEntidad.class))).thenReturn(entidadBase());
+
+        Perfil resultado = perfilGateway.insertarPerfil(perfilBase());
+
+        assertNotNull(resultado);
+        assertEquals(ID,     resultado.getId());
+        assertEquals(CORREO, resultado.getCorreo());
+        verify(repoPerfil).save(any(PerfilEntidad.class));
+    }
+
+    @Test
+    void insertarPerfil_perfilYaExistente_lanzaYaExisteElementoExcepcion() {
+        when(repoPerfil.existsById(ID)).thenReturn(true);
+
+        assertThrows(YaExisteElementoExcepcion.class,
+                () -> perfilGateway.insertarPerfil(perfilBase()));
+
+        verify(repoPerfil, never()).save(any());
+    }
+
+    @Test
+    void insertarPerfil_imagenNoExistente_lanzaDependenciaFallida() {
+        when(repoPerfil.existsById(ID)).thenReturn(false);
+        when(repoImagen.existsById(IMAGEN)).thenReturn(false);
+
+        assertThrows(DependenciaFallida.class,
+                () -> perfilGateway.insertarPerfil(perfilBase()));
+
+        verify(repoPerfil, never()).save(any());
+    }
+
+    // ── obtenerUsuario ──────────────────────────────────────────────────────
+
+    @Test
+    void obtenerUsuario_emailNoExistente_retornaNull() {
+        when(repoPerfil.findByPerfcorreo(anyString())).thenReturn(List.of());
+
+        Perfil resultado = perfilGateway.obtenerUsuario("desconocido@externo.com");
+
+        assertNull(resultado);
+    }
+
+    @Test
+    void obtenerUsuario_emailExistente_esCoordinador_retornaPerfilConRolAdministrador() {
+        when(repoPerfil.findByPerfcorreo(CORREO)).thenReturn(List.of(entidadBase()));
+        when(repoCoordinador.existsById(ID)).thenReturn(true);
+
+        Perfil resultado = perfilGateway.obtenerUsuario(CORREO);
+
+        assertNotNull(resultado);
+        assertEquals(ID,              resultado.getId());
+        assertEquals(CORREO,          resultado.getCorreo());
+        assertEquals("Coordinador", resultado.getRol());
+    }
+
+    @Test
+    void obtenerUsuario_emailExistente_esInstructor_retornaPerfilConRolInstructor() {
+        when(repoPerfil.findByPerfcorreo(CORREO)).thenReturn(List.of(entidadBase()));
+        when(repoCoordinador.existsById(ID)).thenReturn(false);
+        when(repoInstructor.existsById(ID)).thenReturn(true);
+
+        Perfil resultado = perfilGateway.obtenerUsuario(CORREO);
+
+        assertNotNull(resultado);
+        assertEquals("Instructor", resultado.getRol());
+    }
+
+    @Test
+    void obtenerUsuario_emailExistente_esAlumno_retornaPerfilConRolAlumno() {
+        AlumnoEntidad alumno = new AlumnoEntidad();
+        alumno.setIdPerfil(ID);
+        alumno.setTipoAlumno(TIPO_ALM);
+
+        when(repoPerfil.findByPerfcorreo(CORREO)).thenReturn(List.of(entidadBase()));
+        when(repoCoordinador.existsById(ID)).thenReturn(false);
+        when(repoInstructor.existsById(ID)).thenReturn(false);
+        when(repoAlumno.existsById(ID)).thenReturn(true);
+        when(repoAlumno.findById(ID)).thenReturn(Optional.of(alumno));
+        when(repoAlumno.obtenerFacultadPorPerfilId(ID)).thenReturn("Ingeniería");
+
+        Perfil resultado = perfilGateway.obtenerUsuario(CORREO);
+
+        assertNotNull(resultado);
+        assertEquals("Alumno",     resultado.getRol());
+        assertEquals(TIPO_ALM,     resultado.getTipoAlumno());
+        assertEquals("Ingeniería", resultado.getFacultad());
+    }
+
+    @Test
+    void obtenerUsuario_emailExistente_sinRol_retornaNull() {
+        when(repoPerfil.findByPerfcorreo(CORREO)).thenReturn(List.of(entidadBase()));
+        when(repoCoordinador.existsById(ID)).thenReturn(false);
+        when(repoInstructor.existsById(ID)).thenReturn(false);
+        when(repoAlumno.existsById(ID)).thenReturn(false);
+
+        Perfil resultado = perfilGateway.obtenerUsuario(CORREO);
+
+        assertNull(resultado);
+    }
+
+    // ── registrarAlumno ─────────────────────────────────────────────────────
+
+    @Test
+    void registrarAlumno_perfilYaExistente_lanzaYaExisteElementoExcepcion() {
+        when(repoPerfil.existsById(ID)).thenReturn(true);
+
+        assertThrows(YaExisteElementoExcepcion.class,
+                () -> perfilGateway.registrarAlumno(perfilBase()));
+
+        verify(repoPerfil, never()).save(any());
+    }
+
     @Test
     void registrarAlumno_conAlumnoCodigo_persisteEnAlmCodigo() {
-        String id = "12345678";
-        String codigoEstudiantil = "2025-CIEN-001";
-
         Perfil perfil = new Perfil();
-        perfil.setId(id);
-        perfil.setNombre("Juan Test");
-        perfil.setCorreo("juan@unicauca.edu.co");
-        perfil.setTipoId("CC");
-        perfil.setSexo("M");
-        perfil.setTipoAlumno("Regular");
-        perfil.setAlumnoCodigo(codigoEstudiantil);
+        perfil.setId(ID);
+        perfil.setNombre(NOMBRE);
+        perfil.setCorreo(CORREO);
+        perfil.setTipoId(TIPO_ID);
+        perfil.setSexo(SEXO);
+        perfil.setTipoAlumno(TIPO_ALM);
+        perfil.setAlumnoCodigo(ALM_COD);
 
-        when(repoPerfil.existsById(id)).thenReturn(false);
+        when(repoPerfil.existsById(ID)).thenReturn(false);
         when(repoPerfil.save(any(PerfilEntidad.class))).thenReturn(new PerfilEntidad());
         when(repoAlumno.save(any(AlumnoEntidad.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -66,6 +221,6 @@ class PerfilGatewayTest {
 
         ArgumentCaptor<AlumnoEntidad> captor = ArgumentCaptor.forClass(AlumnoEntidad.class);
         verify(repoAlumno).save(captor.capture());
-        assertEquals(codigoEstudiantil, captor.getValue().getAlm_codigo());
+        assertEquals(ALM_COD, captor.getValue().getAlm_codigo());
     }
 }

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/PerfilMapperTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/infraestructura/mappers/PerfilMapperTest.java
@@ -1,0 +1,168 @@
+package co.edu.unicauca.deporteParaTodos.infraestructura.mappers;
+
+import co.edu.unicauca.deporteParaTodos.dominio.excepciones.NoProcesableEntidadException;
+import co.edu.unicauca.deporteParaTodos.dominio.modelo.Perfil;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.DTOs.PerfilDto;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresSecundarios.persistenciaSQL.entidades.PerfilEntidad;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PerfilMapperTest {
+
+    private static final String ID       = "12345678";
+    private static final String NOMBRE   = "Juan García";
+    private static final String CORREO   = "juan@unicauca.edu.co";
+    private static final Integer IMAGEN  = 1;
+    private static final String TIPO_ID  = "CC";
+    private static final String SEXO     = "M";
+    private static final String ROL      = "ALUMNO";
+    private static final String FACULTAD = "Ingeniería";
+    private static final String TIPO_ALM = "Regular";
+    private static final String ALM_COD  = "2025-001";
+
+    private PerfilEntidad entidadBase() {
+        PerfilEntidad e = new PerfilEntidad();
+        e.setPerf_id(ID);
+        e.setPerf_nombre(NOMBRE);
+        e.setPerfcorreo(CORREO);
+        e.setPerf_imagen(IMAGEN);
+        e.setPerf_tipo(TIPO_ID);
+        e.setPerf_Sexo(SEXO);
+        e.setEliminado(0);
+        return e;
+    }
+
+    private Perfil perfilBase() {
+        Perfil p = new Perfil();
+        p.setId(ID);
+        p.setNombre(NOMBRE);
+        p.setCorreo(CORREO);
+        p.setImagen(IMAGEN);
+        p.setTipoId(TIPO_ID);
+        p.setSexo(SEXO);
+        p.setRol(ROL);
+        p.setFacultad(FACULTAD);
+        p.setTipoAlumno(TIPO_ALM);
+        p.setAlumnoCodigo(ALM_COD);
+        return p;
+    }
+
+    private PerfilDto dtoBase() {
+        PerfilDto d = new PerfilDto();
+        d.setId(ID);
+        d.setNombre(NOMBRE);
+        d.setCorreo(CORREO);
+        d.setTipoId(TIPO_ID);
+        d.setSexo(SEXO);
+        d.setRole(ROL);
+        d.setFacultad(FACULTAD);
+        d.setTipoAlumno(TIPO_ALM);
+        d.setAlumnoCodigo(ALM_COD);
+        return d;
+    }
+
+    // ────────── toDominio ──────────
+
+    @Test
+    void toDominio_entidadNula_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> PerfilMapper.toDominio(null));
+    }
+
+    @Test
+    void toDominio_mapea6CamposDeEntidad() {
+        Perfil resultado = PerfilMapper.toDominio(entidadBase());
+        assertEquals(ID,      resultado.getId());
+        assertEquals(NOMBRE,  resultado.getNombre());
+        assertEquals(CORREO,  resultado.getCorreo());   // campo perfcorreo sin guión bajo
+        assertEquals(IMAGEN,  resultado.getImagen());
+        assertEquals(TIPO_ID, resultado.getTipoId());
+        assertEquals(SEXO,    resultado.getSexo());
+    }
+
+    @Test
+    void toDominio_hardcodea_rol_facultad_tipoAlumno_null() {
+        Perfil resultado = PerfilMapper.toDominio(entidadBase());
+        assertNull(resultado.getRol());
+        assertNull(resultado.getFacultad());
+        assertNull(resultado.getTipoAlumno());
+    }
+
+    // ────────── toEntidad ──────────
+
+    @Test
+    void toEntidad_perfilNulo_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> PerfilMapper.toEntidad(null));
+    }
+
+    @Test
+    void toEntidad_mapea6CamposAEntidad() {
+        PerfilEntidad resultado = PerfilMapper.toEntidad(perfilBase());
+        assertEquals(ID,      resultado.getPerf_id());
+        assertEquals(NOMBRE,  resultado.getPerf_nombre());
+        assertEquals(CORREO,  resultado.getPerfcorreo());   // sin guión bajo
+        assertEquals(IMAGEN,  resultado.getPerf_imagen());
+        assertEquals(TIPO_ID, resultado.getPerf_tipo());
+        assertEquals(SEXO,    resultado.getPerf_Sexo());    // S mayúscula
+    }
+
+    @Test
+    void toEntidad_hardcodeoEliminadoCero() {
+        PerfilEntidad resultado = PerfilMapper.toEntidad(perfilBase());
+        assertEquals(0, resultado.getEliminado());
+    }
+
+    // ────────── toDto ──────────
+
+    @Test
+    void toDto_perfilNulo_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> PerfilMapper.toDto(null));
+    }
+
+    @Test
+    void toDto_mapeaCamposCorrectos_incluyendoRolARole() {
+        PerfilDto resultado = PerfilMapper.toDto(perfilBase());
+        assertEquals(ID,      resultado.getId());
+        assertEquals(NOMBRE,  resultado.getNombre());
+        assertEquals(CORREO,  resultado.getCorreo());
+        assertEquals(ROL,     resultado.getRole());     // ASIMÉTRICO: rol → role
+        assertEquals(SEXO,    resultado.getSexo());
+        assertEquals(TIPO_ID, resultado.getTipoId());
+        assertEquals(FACULTAD, resultado.getFacultad());
+        assertEquals(TIPO_ALM, resultado.getTipoAlumno());
+    }
+
+    @Test
+    void toDto_noMapeaAlumnoCodigo() {
+        PerfilDto resultado = PerfilMapper.toDto(perfilBase());
+        assertNull(resultado.getAlumnoCodigo());
+    }
+
+    // ────────── fromDto ──────────
+
+    @Test
+    void fromDto_dtoNulo_lanzaNoProcesableEntidadException() {
+        assertThrows(NoProcesableEntidadException.class, () -> PerfilMapper.fromDto(null));
+    }
+
+    @Test
+    void fromDto_mapeaCamposCorrectos_incluyendoRoleARol() {
+        Perfil resultado = PerfilMapper.fromDto(dtoBase());
+        assertEquals(ID,       resultado.getId());
+        assertEquals(NOMBRE,   resultado.getNombre());
+        assertEquals(CORREO,   resultado.getCorreo());
+        assertEquals(TIPO_ID,  resultado.getTipoId());
+        assertEquals(SEXO,     resultado.getSexo());
+        assertEquals(ROL,      resultado.getRol());     // ASIMÉTRICO: role → rol
+        assertEquals(FACULTAD, resultado.getFacultad());
+        assertEquals(TIPO_ALM, resultado.getTipoAlumno());
+        assertEquals(ALM_COD,  resultado.getAlumnoCodigo());
+    }
+
+    @Test
+    void fromDto_hardcodea_imagenNull_mapeaAlumnoCodigo() {
+        Perfil resultado = PerfilMapper.fromDto(dtoBase());
+        assertNull(resultado.getImagen());
+        assertEquals(ALM_COD, resultado.getAlumnoCodigo());
+    }
+}


### PR DESCRIPTION
Se detecto que, tras la Fase 1 de autenticacion (SCRUM-156), TODOS 
los endpoints protegidos rechazaban con 401 el token propio del 
sistema (dpt_token, firmado HS256), porque el unico JwtDecoder 
configurado solo sabia validar tokens de Google (RS256/JWKS). El 
gap era pre-existente desde la implementacion original de seguridad, 
no introducido por el refactor de Perfil (H-01/02/05).

Solucion: se separo SecurityConfig en 2 SecurityFilterChain con 
@Order -- una exclusiva para /api/v2/auth/token (sin filtro Bearer, 
decodifica el token de Google manualmente en el controller), y otra 
para el resto de endpoints (valida dpt_token con un nuevo 
systemJwtDecoder HS256/JWT_SECRET).

Verificado end-to-end: login real con Google, POST /auth/token sigue 
en 200, y los endpoints protegidos (categorias, cursos) ahora 
responden 200 en vez de 401.

311/311 tests, BUILD SUCCESS.