### PR TITLE
exigir autenticacion real - el candado de seguridad ya esta activo

### DIFF
--- a/src/main/java/co/edu/unicauca/deporteParaTodos/configurations/SecurityConfig.java
+++ b/src/main/java/co/edu/unicauca/deporteParaTodos/configurations/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -57,8 +58,8 @@ public class SecurityConfig {
     }
 
     // Chain 2 (Orden 2): todos los demas endpoints — valida dpt_token (HS256/JWT_SECRET).
-    // Fase 1a: permitAll() — no rompe endpoints existentes.
-    // Fase 1b (siguiente commit): restringir endpoints con .authenticated()
+    // SCRUM-156 Fase 1c: solo POST /api/v2/RegistroPerfilAlumno es publico (SCRUM-160).
+    // Todo lo demas exige autenticacion con dpt_token valido.
     @Bean
     @Order(2)
     public SecurityFilterChain mainChain(HttpSecurity http) throws Exception {
@@ -71,7 +72,9 @@ public class SecurityConfig {
             .csrf(AbstractHttpConfigurer::disable) // NOSONAR: jwt-stateless-no-csrf-risk
             .sessionManagement(session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.POST, "/api/v2/RegistroPerfilAlumno").permitAll()
+                .anyRequest().authenticated())
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(systemJwtDecoder())));
         return http.build();
     }

--- a/src/test/java/co/edu/unicauca/deporteParaTodos/configurations/SecurityFilterChainTest.java
+++ b/src/test/java/co/edu/unicauca/deporteParaTodos/configurations/SecurityFilterChainTest.java
@@ -1,0 +1,110 @@
+package co.edu.unicauca.deporteParaTodos.configurations;
+
+import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.IAutenticacionServicio;
+import co.edu.unicauca.deporteParaTodos.aplicacion.puertos.puertosEntrada.IDeporteServicio;
+import co.edu.unicauca.deporteParaTodos.dominio.servicios.TokenServicio;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.api.AutenticacionRest;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.api.DeporteRest;
+import co.edu.unicauca.deporteParaTodos.infraestructura.adaptadores.adaptadoresPrimarios.adaptadorRest.api.TokenInterchangeRest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {DeporteRest.class, AutenticacionRest.class, TokenInterchangeRest.class})
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = {
+        "app.jwt.secret=dGVzdFNlY3JldEtleUZvckNJMTIzNDU2Nzg5MDEyMzQ1Njc4OTA=",
+        "spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://www.googleapis.com/oauth2/v3/certs"
+})
+class SecurityFilterChainTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtEncoder jwtEncoder;
+
+    @MockBean
+    private IDeporteServicio servicioDeporte;
+
+    @MockBean
+    private IAutenticacionServicio servicioAutenticacion;
+
+    @MockBean
+    private TokenServicio tokenServicio;
+
+    // ── Test 1: endpoint protegido sin token → 401 de Spring Security ────────
+
+    @Test
+    void getEndpointProtegido_sinToken_retorna401() throws Exception {
+        mockMvc.perform(get("/api/v2/deportes"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── Test 2: endpoint protegido con dpt_token válido → Spring Security lo deja pasar ──
+
+    @Test
+    void getEndpointProtegido_conDptTokenValido_retorna200() throws Exception {
+        when(servicioDeporte.listaDeportes()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v2/deportes")
+                        .header("Authorization", "Bearer " + generarTokenValido()))
+                .andExpect(status().isOk());
+    }
+
+    // ── Test 3: POST /api/v2/RegistroPerfilAlumno sin token → NO 401 (endpoint público) ──
+
+    @Test
+    void postRegistroAlumno_sinToken_noEsBloqueadoPorSecurity() throws Exception {
+        // Security permite el request (permitAll); la validacion del body devuelve 400,
+        // pero nunca 401 — eso confirma que el matcher de permitAll funciona correctamente.
+        mockMvc.perform(post("/api/v2/RegistroPerfilAlumno")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().is(not(401)));
+    }
+
+    // ── Test 4: POST /api/v2/auth/token sin Google token → 401 del CONTROLLER, no de Security ──
+
+    @Test
+    void postAuthToken_sinGoogleToken_retorna401DelController_noDeSpringSecurityFilter() throws Exception {
+        // tokenExchangeChain usa permitAll() — Spring Security no bloquea la ruta.
+        // El 401 lo devuelve TokenInterchangeRest al detectar ausencia de Authorization header.
+        // El 401 de Spring Security incluiría WWW-Authenticate; el del controller no lo incluye.
+        mockMvc.perform(post("/api/v2/auth/token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().doesNotExist("WWW-Authenticate"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private String generarTokenValido() {
+        JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .subject("test-user")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+        return jwtEncoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
+    }
+}


### PR DESCRIPTION
Cambio critico de seguridad: SecurityConfig pasa de permitAll() a 
anyRequest().authenticated() en todos los endpoints, excepto 
POST /api/v2/auth/token (intercambio de token) y 
POST /api/v2/RegistroPerfilAlumno (autoregistro, decision documentada 
en SCRUM-160 -- endpoint puente temporal hasta integracion con TIC).

Inventario completo de 49 endpoints clasificados. 4 tests nuevos de 
comportamiento de SecurityFilterChain. 313 tests, BUILD SUCCESS.

Verificado manualmente end-to-end: sin sesion -> 401 en todos los 
endpoints protegidos; con sesion -> flujo completo funcional 
(categorias, cursos, grupos, horarios, inscripciones).

Cierra la vulnerabilidad critica original documentada en SCRUM-156: 
cualquiera podia acceder al sistema solo con conocer un correo 
registrado, sin ninguna verificacion criptografica.